### PR TITLE
feat(a11y): semantics and theme mode persistence

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -58,7 +58,7 @@ class MyApp extends StatelessWidget {
           // Use the Diaspora Connection theme definitions for light and dark modes
           theme: FoutaThemeDiaspora.lightTheme,
           darkTheme: FoutaThemeDiaspora.darkTheme,
-          themeMode: themeProvider.isDarkMode ? ThemeMode.dark : ThemeMode.light,
+          themeMode: themeProvider.themeMode,
           home: const SplashScreen(),
         );
       },

--- a/lib/screens/story_camera_screen.dart
+++ b/lib/screens/story_camera_screen.dart
@@ -201,41 +201,46 @@ class _StoryCameraScreenState extends State<StoryCameraScreen> {
                     IconButton(
                       iconSize: 32,
                       icon: const Icon(Icons.photo_library, color: Colors.white),
+                      tooltip: 'Pick from gallery',
                       onPressed: _pickFromGallery,
                     ),
                   ],
                 ),
                 const SizedBox(height: 16),
-                GestureDetector(
-                  onTap: _takePhoto,
-                  onLongPressStart: (_) {
-                    setState(() => _isRecording = true);
-                    _startVideoRecording();
-                  },
-                  onLongPressEnd: (_) async {
-                    if (_isRecording) {
-                      setState(() => _isRecording = false);
-                      await _stopVideoRecording();
-                    }
-                  },
-                  child: Container(
-                    width: 80,
-                    height: 80,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: Colors.white.withOpacity(0.2),
-                      border: Border.all(
-                        color: Colors.white,
-                        width: 4,
+                Semantics(
+                  label: 'Capture story',
+                  button: true,
+                  child: GestureDetector(
+                    onTap: _takePhoto,
+                    onLongPressStart: (_) {
+                      setState(() => _isRecording = true);
+                      _startVideoRecording();
+                    },
+                    onLongPressEnd: (_) async {
+                      if (_isRecording) {
+                        setState(() => _isRecording = false);
+                        await _stopVideoRecording();
+                      }
+                    },
+                    child: Container(
+                      width: 80,
+                      height: 80,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: Colors.white.withOpacity(0.2),
+                        border: Border.all(
+                          color: Colors.white,
+                          width: 4,
+                        ),
                       ),
-                    ),
-                    child: Center(
-                      child: Container(
-                        width: 60,
-                        height: 60,
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          color: _isRecording ? Colors.red : Colors.white,
+                      child: Center(
+                        child: Container(
+                          width: 60,
+                          height: 60,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: _isRecording ? Colors.red : Colors.white,
+                          ),
                         ),
                       ),
                     ),

--- a/lib/screens/story_viewer_screen.dart
+++ b/lib/screens/story_viewer_screen.dart
@@ -255,10 +255,13 @@ class _StoryViewerScreenState extends State<StoryViewerScreen> with TickerProvid
                   if (currentSlide.mediaType == 'video')
                     Center(
                       child: _videoController != null
-                          ? Video(
-                              key: ValueKey(currentSlide.id),
-                              controller: _videoController!,
-                              fit: BoxFit.contain,
+                          ? Semantics(
+                              label: 'Story video',
+                              child: Video(
+                                key: ValueKey(currentSlide.id),
+                                controller: _videoController!,
+                                fit: BoxFit.contain,
+                              ),
                             )
                           : const Center(
                               child: CircularProgressIndicator(
@@ -268,11 +271,14 @@ class _StoryViewerScreenState extends State<StoryViewerScreen> with TickerProvid
                     )
                   else
                     Center(
-                      child: CachedNetworkImage(
-                        imageUrl: currentSlide.url,
-                        fit: BoxFit.contain,
-                        placeholder: (context, url) => const Center(child: CircularProgressIndicator()),
-                        errorWidget: (context, url, error) => const Center(child: Icon(Icons.error, color: Colors.white)),
+                      child: Semantics(
+                        label: 'Story image',
+                        child: CachedNetworkImage(
+                          imageUrl: currentSlide.url,
+                          fit: BoxFit.contain,
+                          placeholder: (context, url) => const Center(child: CircularProgressIndicator()),
+                          errorWidget: (context, url, error) => const Center(child: Icon(Icons.error, color: Colors.white)),
+                        ),
                       ),
                     ),
                   _buildOverlay(context, currentStory, currentSlide),

--- a/lib/screens/unified_settings_screen.dart
+++ b/lib/screens/unified_settings_screen.dart
@@ -216,19 +216,28 @@ class _UnifiedSettingsScreenState extends State<UnifiedSettingsScreen> {
           
           _buildSectionHeader('APP'),
 
-          // Dark mode toggle using ThemeProvider. Wrap in Builder to ensure context has access to the provider.
+          // Theme mode selection using ThemeProvider.
           Builder(
             builder: (context) {
               return Consumer<ThemeProvider>(
                 builder: (context, themeProvider, _) {
-                  return SwitchListTile(
-                    secondary: const Icon(Icons.dark_mode_outlined),
-                    title: const Text('Dark Mode'),
-                    subtitle: const Text('Enable dark theme'),
-                    value: themeProvider.isDarkMode,
-                    onChanged: (value) {
-                      themeProvider.setDarkMode(value);
-                    },
+                  return ListTile(
+                    leading: const Icon(Icons.dark_mode_outlined),
+                    title: const Text('Theme Mode'),
+                    subtitle: const Text('Auto, Light, or Dark'),
+                    trailing: DropdownButton<ThemeMode>(
+                      value: themeProvider.themeMode,
+                      onChanged: (mode) {
+                        if (mode != null) {
+                          themeProvider.setThemeMode(mode);
+                        }
+                      },
+                      items: const [
+                        DropdownMenuItem(value: ThemeMode.system, child: Text('Auto')),
+                        DropdownMenuItem(value: ThemeMode.light, child: Text('Light')),
+                        DropdownMenuItem(value: ThemeMode.dark, child: Text('Dark')),
+                      ],
+                    ),
                   );
                 },
               );

--- a/lib/services/theme_provider.dart
+++ b/lib/services/theme_provider.dart
@@ -1,32 +1,41 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-
-/// Provides the app's current theme mode (light or dark) and updates it when
-/// requested. Widgets can listen to [isDarkMode] for rebuilds.
-
+/// Provides the app's current [ThemeMode] and persists changes.
 class ThemeProvider extends ChangeNotifier {
-  bool _isDarkMode = false;
-  bool get isDarkMode => _isDarkMode;
+  ThemeMode _themeMode = ThemeMode.system;
+  ThemeMode get themeMode => _themeMode;
 
   ThemeProvider() {
-    _loadDarkMode();
+    _loadThemeMode();
   }
 
-  Future<void> _loadDarkMode() async {
+  Future<void> _loadThemeMode() async {
     final prefs = await SharedPreferences.getInstance();
-    _isDarkMode = prefs.getBool('isDarkMode') ?? false;
+    final value = prefs.getString('themeMode') ?? 'system';
+    _themeMode = _stringToThemeMode(value);
     notifyListeners();
   }
 
-  /// Sets dark mode to [isDark]. Persists the change and notifies listeners
-  /// only when the value changes.
-  Future<void> setDarkMode(bool isDark) async {
-    if (_isDarkMode == isDark) return;
-    _isDarkMode = isDark;
+  Future<void> setThemeMode(ThemeMode mode) async {
+    if (_themeMode == mode) return;
+    _themeMode = mode;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool('isDarkMode', isDark);
-
+    await prefs.setString('themeMode', _themeMode.toString().split('.').last);
     notifyListeners();
   }
+
+  // Helper to parse a stored string into a ThemeMode value.
+  ThemeMode _stringToThemeMode(String value) {
+    switch (value) {
+      case 'light':
+        return ThemeMode.light;
+      case 'dark':
+        return ThemeMode.dark;
+      default:
+        return ThemeMode.system;
+    }
+  }
+
+  bool get isDarkMode => _themeMode == ThemeMode.dark;
 }

--- a/lib/widgets/media_viewer.dart
+++ b/lib/widgets/media_viewer.dart
@@ -182,12 +182,17 @@ class _MediaFilePageState extends State<_MediaFilePage> {
   Widget build(BuildContext context) {
     if (widget.type == 'image') {
       return Center(
-        child: InteractiveViewer(
-          child: CachedNetworkImage(
-            imageUrl: widget.url,
-            fit: BoxFit.contain,
-            placeholder: (context, url) => const Center(child: CircularProgressIndicator(color: Colors.white)),
-            errorWidget: (context, url, error) => const Center(child: Icon(Icons.broken_image, color: Colors.white)),
+        child: Semantics(
+          label: 'Image preview',
+          child: InteractiveViewer(
+            child: CachedNetworkImage(
+              imageUrl: widget.url,
+              fit: BoxFit.contain,
+              placeholder: (context, url) =>
+                  const Center(child: CircularProgressIndicator(color: Colors.white)),
+              errorWidget: (context, url, error) =>
+                  const Center(child: Icon(Icons.broken_image, color: Colors.white)),
+            ),
           ),
         ),
       );
@@ -206,10 +211,13 @@ class _MediaFilePageState extends State<_MediaFilePage> {
         children: [
           AspectRatio(
             aspectRatio: widget.aspectRatio ?? 16 / 9,
-            child: Video(
-              key: ValueKey(widget.url),
-              controller: _controller!,
-              controls: AdaptiveVideoControls,
+            child: Semantics(
+              label: 'Video preview',
+              child: Video(
+                key: ValueKey(widget.url),
+                controller: _controller!,
+                controls: AdaptiveVideoControls,
+              ),
             ),
           ),
           if (_showControls)

--- a/lib/widgets/stories_tray.dart
+++ b/lib/widgets/stories_tray.dart
@@ -149,38 +149,41 @@ class StoriesTray extends StatelessWidget {
     final bool hasStory = yourIndex != -1;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 4.0),
-      child: GestureDetector(
-        // Always allow the user to create or append a story when tapping the
-        // avatar.  Long‑pressing the avatar opens the viewer for any existing
-        // story.
-        onTap: () {
-          Navigator.push(context,
-              MaterialPageRoute(builder: (_) => const StoryCameraScreen()));
-        },
-        onLongPress: hasStory
-            ? () {
-                final stories = sortedDocs.map((doc) {
-                  final data = doc.data() as Map<String, dynamic>;
-                  return Story(
-                    userId: doc.id,
-                    userName: data['authorName'] ?? 'User',
-                    userImageUrl: data['authorImageUrl'] ?? '',
-                    slides: [],
-                  );
-                }).toList();
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => StoryViewerScreen(
-                      stories: stories,
-                      initialStoryIndex: yourIndex,
+      child: Semantics(
+        label: hasStory ? 'Your story' : 'Create a story',
+        button: true,
+        child: GestureDetector(
+          // Always allow the user to create or append a story when tapping the
+          // avatar.  Long‑pressing the avatar opens the viewer for any existing
+          // story.
+          onTap: () {
+            Navigator.push(context,
+                MaterialPageRoute(builder: (_) => const StoryCameraScreen()));
+          },
+          onLongPress: hasStory
+              ? () {
+                  final stories = sortedDocs.map((doc) {
+                    final data = doc.data() as Map<String, dynamic>;
+                    return Story(
+                      userId: doc.id,
+                      userName: data['authorName'] ?? 'User',
+                      userImageUrl: data['authorImageUrl'] ?? '',
+                      slides: [],
+                    );
+                  }).toList();
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => StoryViewerScreen(
+                        stories: stories,
+                        initialStoryIndex: yourIndex,
+                      ),
                     ),
-                  ),
-                );
-              }
-            : null,
-        child: Column(
-          children: [
+                  );
+                }
+              : null,
+          child: Column(
+            children: [
             Stack(
               alignment: Alignment.bottomRight,
               children: [
@@ -241,10 +244,13 @@ class _StoryAvatar extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 4.0),
-      child: InkWell(
-        onTap: onTap,
-        child: Column(
-          children: [
+      child: Semantics(
+        label: "$userName's story",
+        button: true,
+        child: InkWell(
+          onTap: onTap,
+          child: Column(
+            children: [
             Container(
               padding: const EdgeInsets.all(2.0),
               decoration: BoxDecoration(


### PR DESCRIPTION
## Summary
- add Semantics to story media, camera shutter and media viewer
- allow selecting Auto/Light/Dark and persist theme mode

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896988dbc94832bae941829041bfa48