### PR TITLE
feat(media): unified feed tiles + full-screen viewer with progressive loading and a11y

### DIFF
--- a/lib/models/media_item.dart
+++ b/lib/models/media_item.dart
@@ -1,0 +1,73 @@
+import 'package:meta/meta.dart';
+
+/// Describes an individual media item attached to a post.
+@immutable
+class MediaItem {
+  const MediaItem({
+    required this.type,
+    required this.thumbUrl,
+    required this.previewUrl,
+    required this.fullUrl,
+    required this.width,
+    required this.height,
+    this.duration,
+    this.blurHash,
+    this.captionUrl,
+  });
+
+  final MediaType type;
+  final Uri thumbUrl;
+  final Uri previewUrl;
+  final Uri fullUrl;
+  final double width;
+  final double height;
+  final double? duration;
+  final String? blurHash;
+  final Uri? captionUrl;
+
+  double get aspectRatio => width == 0 ? 1 : width / height;
+
+  factory MediaItem.fromMap(Map<String, dynamic> map) {
+    return MediaItem(
+      type: MediaType.values.firstWhere(
+        (e) => e.name == (map['type'] ?? 'image'),
+        orElse: () => MediaType.image,
+      ),
+      thumbUrl: Uri.parse((map['thumbUrl'] ?? map['url'] ?? '').toString()),
+      previewUrl: Uri.parse((map['previewUrl'] ?? map['url'] ?? '').toString()),
+      fullUrl: Uri.parse((map['fullUrl'] ?? map['url'] ?? '').toString()),
+      width: _extractWidth(map),
+      height: _extractHeight(map),
+      duration: (map['duration'] as num?)?.toDouble(),
+      blurHash: map['blurHash'] as String?,
+      captionUrl:
+          map['captionUrl'] != null ? Uri.parse(map['captionUrl']) : null,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'type': type.name,
+        'thumbUrl': thumbUrl.toString(),
+        'previewUrl': previewUrl.toString(),
+        'fullUrl': fullUrl.toString(),
+        'width': width,
+        'height': height,
+        if (duration != null) 'duration': duration,
+        if (blurHash != null) 'blurHash': blurHash,
+        if (captionUrl != null) 'captionUrl': captionUrl.toString(),
+      };
+}
+
+enum MediaType { image, video }
+
+double _extractWidth(Map<String, dynamic> map) {
+  final num? width = map['width'] as num?;
+  if (width != null) return width.toDouble();
+  final num? aspect = map['aspectRatio'] as num?;
+  return aspect?.toDouble() ?? 1;
+}
+
+double _extractHeight(Map<String, dynamic> map) {
+  final num? height = map['height'] as num?;
+  return height?.toDouble() ?? 1;
+}

--- a/lib/models/post_model.dart
+++ b/lib/models/post_model.dart
@@ -1,0 +1,23 @@
+import 'media_item.dart';
+
+/// Basic post model exposing media attachments.
+class Post {
+  Post({required this.id, required this.content, required this.attachments});
+
+  final String id;
+  final String content;
+  final List<MediaItem> attachments;
+
+  factory Post.fromMap(String id, Map<String, dynamic> data) {
+    final attachmentList =
+        (data['attachments'] as List<dynamic>? ?? <dynamic>[])
+            .whereType<Map<String, dynamic>>()
+            .map(MediaItem.fromMap)
+            .toList();
+    return Post(
+      id: id,
+      content: data['content'] as String? ?? '',
+      attachments: attachmentList,
+    );
+  }
+}

--- a/lib/screens/media_viewer.dart
+++ b/lib/screens/media_viewer.dart
@@ -1,0 +1,121 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:photo_view/photo_view.dart';
+
+import '../models/media_item.dart';
+import '../services/media_prefetcher.dart';
+import '../widgets/media/video_player_view.dart';
+
+/// Displays a full‑screen gallery of media attachments.
+class MediaViewer extends StatefulWidget {
+  const MediaViewer({super.key, required this.media, this.initialIndex = 0});
+
+  final List<MediaItem> media;
+  final int initialIndex;
+
+  @override
+  State<MediaViewer> createState() => _MediaViewerState();
+}
+
+class _MediaViewerState extends State<MediaViewer> {
+  late final PageController _controller;
+  final MediaPrefetcher _prefetcher = const MediaPrefetcher();
+  int _index = 0;
+  double _dragOffset = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _index = widget.initialIndex;
+    _controller = PageController(initialPage: _index);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _prefetchAround(_index));
+  }
+
+  void _prefetchAround(int index) {
+    if (index > 0) {
+      _prefetcher.prefetch(context, widget.media[index - 1]);
+    }
+    if (index + 1 < widget.media.length) {
+      _prefetcher.prefetch(context, widget.media[index + 1]);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return GestureDetector(
+      onVerticalDragUpdate: (details) {
+        _dragOffset += details.primaryDelta ?? 0;
+        if (_dragOffset.abs() > 150) {
+          Navigator.of(context).maybePop();
+        }
+      },
+      onVerticalDragEnd: (_) => _dragOffset = 0,
+      child: Scaffold(
+        backgroundColor: colorScheme.surface,
+        body: Stack(
+          children: [
+            PageView.builder(
+              controller: _controller,
+              itemCount: widget.media.length,
+              onPageChanged: (i) {
+                setState(() => _index = i);
+                _prefetchAround(i);
+              },
+              itemBuilder: (context, index) {
+                final item = widget.media[index];
+                final tag = item.fullUrl.toString();
+                switch (item.type) {
+                  case MediaType.image:
+                    return Hero(
+                      tag: tag,
+                      child: PhotoView(
+                        imageProvider:
+                            CachedNetworkImageProvider(item.fullUrl.toString()),
+                        heroAttributes: PhotoViewHeroAttributes(tag: tag),
+                      ),
+                    );
+                  case MediaType.video:
+                    return Center(
+                      child: Hero(
+                        tag: tag,
+                        child: VideoPlayerView(
+                          url: item.fullUrl,
+                          autoplay: index == _index,
+                        ),
+                      ),
+                    );
+                }
+              },
+            ),
+            SafeArea(
+              child: Align(
+                alignment: Alignment.topLeft,
+                child: IconButton(
+                  icon: const Icon(Icons.close),
+                  color: colorScheme.onSurface,
+                  onPressed: () => Navigator.of(context).maybePop(),
+                  tooltip: 'Close',
+                ),
+              ),
+            ),
+            Positioned(
+              bottom: 24 + MediaQuery.of(context).padding.bottom,
+              left: 0,
+              right: 0,
+              child: Center(
+                child: Text(
+                  '${_index + 1} / ${widget.media.length}',
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyMedium
+                      ?.copyWith(color: colorScheme.onSurface),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/media_prefetcher.dart
+++ b/lib/services/media_prefetcher.dart
@@ -1,0 +1,29 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/widgets.dart';
+import 'package:video_player/video_player.dart';
+
+import '../models/media_item.dart';
+
+/// Preloads image and video assets to provide a smoother viewing experience.
+class MediaPrefetcher {
+  const MediaPrefetcher();
+
+  Future<void> prefetch(BuildContext context, MediaItem item) async {
+    switch (item.type) {
+      case MediaType.image:
+        await precacheImage(
+          CachedNetworkImageProvider(item.previewUrl.toString()),
+          context,
+        );
+        break;
+      case MediaType.video:
+        final controller = VideoPlayerController.networkUrl(item.previewUrl);
+        try {
+          await controller.initialize();
+        } finally {
+          await controller.dispose();
+        }
+        break;
+    }
+  }
+}

--- a/lib/widgets/media/post_media.dart
+++ b/lib/widgets/media/post_media.dart
@@ -1,0 +1,111 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_blurhash/flutter_blurhash.dart';
+import 'video_player_view.dart';
+
+import '../../models/media_item.dart';
+import '../../screens/media_viewer.dart';
+
+/// Renders attachments within the feed.
+class PostMedia extends StatelessWidget {
+  const PostMedia({super.key, required this.media});
+
+  final List<MediaItem> media;
+
+  double _clampAspectRatio(double ratio) {
+    const double minRatio = 4 / 5;
+    const double maxRatio = 16 / 9;
+    if (ratio < minRatio) return minRatio;
+    if (ratio > maxRatio) return maxRatio;
+    return ratio;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (media.isEmpty) return const SizedBox.shrink();
+    final MediaItem first = media.first;
+    final double aspect = _clampAspectRatio(first.aspectRatio);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    Widget child;
+    switch (first.type) {
+      case MediaType.image:
+        child = CachedNetworkImage(
+          imageUrl: first.previewUrl.toString(),
+          placeholder: (context, url) => first.blurHash != null
+              ? BlurHash(
+                  hash: first.blurHash!,
+                  imageFit: BoxFit.cover,
+                )
+              : Container(color: colorScheme.surfaceVariant),
+          fit: BoxFit.cover,
+        );
+        break;
+      case MediaType.video:
+        child = VideoPlayerView(url: first.previewUrl);
+        break;
+    }
+    return Semantics(
+      label: first.type == MediaType.image ? 'Image preview' : 'Video preview',
+      child: GestureDetector(
+        onTap: () => Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => MediaViewer(media: media, initialIndex: 0),
+          ),
+        ),
+        child: AspectRatio(
+          aspectRatio: aspect,
+          child: Hero(
+            tag: first.fullUrl.toString(),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  child,
+                  if (media.length > 1)
+                    Positioned(
+                      right: 8,
+                      top: 8,
+                      child: Container(
+                        padding:
+                            const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: colorScheme.surface.withOpacity(0.5),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Text(
+                          media.length.toString(),
+                          style: theme.textTheme.labelMedium?.copyWith(
+                            color: colorScheme.onSurface,
+                          ),
+                        ),
+                      ),
+                    ),
+                  Positioned(
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    height: 60,
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.bottomCenter,
+                          end: Alignment.topCenter,
+                          colors: [
+                            colorScheme.scrim.withOpacity(0.7),
+                            colorScheme.scrim.withOpacity(0),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/media/video_player_view.dart
+++ b/lib/widgets/media/video_player_view.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+
+/// A minimal video player with tap‑to‑pause controls.
+class VideoPlayerView extends StatefulWidget {
+  const VideoPlayerView({super.key, required this.url, this.autoplay = true});
+
+  final Uri url;
+  final bool autoplay;
+
+  @override
+  State<VideoPlayerView> createState() => _VideoPlayerViewState();
+}
+
+class _VideoPlayerViewState extends State<VideoPlayerView>
+    with AutomaticKeepAliveClientMixin {
+  late final VideoPlayerController _controller;
+  bool _initialized = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = VideoPlayerController.networkUrl(widget.url)
+      ..setLooping(true)
+      ..initialize().then((_) {
+        setState(() => _initialized = true);
+        if (widget.autoplay) _controller.play();
+      });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    if (!_initialized) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    final colorScheme = Theme.of(context).colorScheme;
+    return GestureDetector(
+      onTap: () {
+        if (_controller.value.isPlaying) {
+          _controller.pause();
+        } else {
+          _controller.play();
+        }
+        setState(() {});
+      },
+      child: Stack(
+        children: [
+          VideoPlayer(_controller),
+          Positioned(
+            bottom: 8,
+            left: 8,
+            child: Icon(
+              _controller.value.isPlaying ? Icons.pause : Icons.play_arrow,
+              color: colorScheme.onSurface,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/post_card_widget.dart
+++ b/lib/widgets/post_card_widget.dart
@@ -12,7 +12,8 @@ import 'package:fouta_app/main.dart'; // Import APP_ID
 import 'package:fouta_app/screens/create_post_screen.dart';
 import 'package:fouta_app/screens/profile_screen.dart';
 // Use the unified MediaViewer instead of separate full screen image/video widgets
-import 'package:fouta_app/widgets/media_viewer.dart';
+import '../models/media_item.dart';
+import 'media/post_media.dart';
 import 'package:fouta_app/widgets/share_post_dialog.dart';
 import 'package:fouta_app/widgets/fouta_card.dart';
 
@@ -558,105 +559,11 @@ class _PostCardWidgetState extends State<PostCardWidget> {
   /// opens a full‑screen [MediaViewer] with all attachments for this post.
   Widget _buildAttachmentThumbnail(List<dynamic> attachments) {
     if (attachments.isEmpty) return const SizedBox.shrink();
-    final Map<String, dynamic> first = attachments.first as Map<String, dynamic>;
-    final String type = first['type'] ?? 'image';
-    final String url = first['url'] ?? '';
-    final double? aspectRatio = first['aspectRatio'] as double?;
-    final bool allowAutoplay = !widget.isDataSaverOn || !widget.isOnMobileData;
-    Widget thumb;
-    switch (type) {
-      case 'image':
-        thumb = ClipRRect(
-          borderRadius: BorderRadius.circular(8.0),
-          child: CachedNetworkImage(
-            imageUrl: url,
-            placeholder: (context, url) => AspectRatio(
-              aspectRatio: 16 / 9,
-              child: Container(
-                color: Colors.grey[300],
-                child: const Center(child: CircularProgressIndicator()),
-              ),
-            ),
-            errorWidget: (context, url, error) => Container(
-              height: 200,
-              color: Colors.grey[300],
-              child: const Center(child: Icon(Icons.broken_image, color: Colors.grey, size: 50)),
-            ),
-            width: double.infinity,
-            fit: BoxFit.cover,
-          ),
-        );
-        break;
-      case 'video':
-        if (allowAutoplay) {
-          thumb = ClipRRect(
-            borderRadius: BorderRadius.circular(8.0),
-            child: VideoPlayerWidget(
-              videoUrl: url,
-              videoId: widget.postId,
-              aspectRatio: aspectRatio,
-              areControlsVisible: false,
-              shouldInitialize: _isPostVisible,
-            ),
-          );
-        } else {
-          thumb = ClipRRect(
-            borderRadius: BorderRadius.circular(8.0),
-            child: AspectRatio(
-              aspectRatio: aspectRatio ?? 16 / 9,
-              child: Stack(
-                fit: StackFit.expand,
-                children: [
-                  // Thumbnail placeholder for video.  Currently we just show a dark
-                  // container with a play icon overlay.  In the future, we can
-                  // generate actual video thumbnails during upload.
-                  Container(color: Colors.black54),
-                  const Center(
-                    child: Icon(Icons.play_circle_fill, color: Colors.white70, size: 56),
-                  ),
-                ],
-              ),
-            ),
-          );
-        }
-        break;
-      default:
-        thumb = const SizedBox.shrink();
-    }
-    return GestureDetector(
-      onTap: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => MediaViewer(
-              mediaList: attachments.cast<Map<String, dynamic>>(),
-              initialIndex: 0,
-            ),
-          ),
-        );
-      },
-      child: Stack(
-        children: [
-          thumb,
-          if (attachments.length > 1)
-            Positioned(
-              right: 8,
-              bottom: 8,
-              child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                decoration: BoxDecoration(
-                  color: Colors.black54,
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Text(
-                  '+${attachments.length - 1}',
-                  style: const TextStyle(color: Colors.white, fontSize: 12),
-                ),
-              ),
-            ),
-        ],
-      ),
-    );
+    final items = attachments
+        .whereType<Map<String, dynamic>>()
+        .map(MediaItem.fromMap)
+        .toList();
+    return PostMedia(media: items);
   }
 
   void _showLikesDialog(BuildContext context, List<dynamic> likerIds) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,10 @@ dependencies:
   # including Linux, align with the current platform interface and expose
   # `startStream`.
   record: ^5.1.1
+  photo_view: ^0.14.0
+  flutter_blurhash: ^0.7.0
+  video_player: ^2.8.2
+  subtitle_wrapper_package: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `MediaItem` model and prefetch service
- render post attachments with new `PostMedia` widget and video player
- introduce full-screen `MediaViewer` with gesture controls

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68969f45f550832bb7265b1ae989f2dd