### PR TITLE
[Chore] pubspec dedupe + duplicate checker

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,19 @@
+name: Validation
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter doctor -v
+      - name: Run duplicate check and pub get
+        run: |
+          chmod +x scripts/validate.sh
+          bash scripts/validate.sh

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,6 @@ dependencies:
   # `startStream`.
   record: ^5.1.1
   photo_view: ^0.14.0
-  flutter_blurhash: ^0.7.0
   video_player: ^2.8.2
   subtitle_wrapper_package: ^2.0.0
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+mkdir -p build/validation
+
+echo "== Check pubspec duplicates =="
+if ! dart run tool/check_pubspec_dupes.dart | tee build/validation/pubspec_dupes.txt; then
+  echo "Duplicate keys found in pubspec.yaml"
+  exit 1
+fi
+
+echo "== flutter pub get =="
+flutter pub get

--- a/tool/check_pubspec_dupes.dart
+++ b/tool/check_pubspec_dupes.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+void main() {
+  final file = File('pubspec.yaml');
+  if (!file.existsSync()) {
+    stderr.writeln('pubspec.yaml not found');
+    exit(2);
+  }
+  final lines = file.readAsLinesSync();
+
+  bool isTopLevel(String line) =>
+      RegExp(r'^[A-Za-z_][A-Za-z0-9_]*\s*:').hasMatch(line.trimLeft()) &&
+      !line.startsWith('  ');
+  final keyLine = RegExp(r'^\s{2}([A-Za-z0-9_]+)\s*:');
+
+  int scanSection(String name) {
+    final start = lines.indexWhere((l) => l.trim() == '$name:');
+    if (start == -1) return 0;
+    final seen = <String,int>{};
+    for (int i = start + 1; i < lines.length; i++) {
+      final line = lines[i];
+      if (isTopLevel(line)) break;
+      final m = keyLine.firstMatch(line);
+      if (m != null) {
+        final k = m.group(1)!;
+        seen.update(k, (v) => v + 1, ifAbsent: () => 1);
+      }
+    }
+    int dupes = 0;
+    seen.forEach((k, v) {
+      if (v > 1) {
+        stderr.writeln('Duplicate in $name: $k appears $v times');
+        dupes += v - 1;
+      }
+    });
+    return dupes;
+  }
+
+  final totalDupes = scanSection('dependencies')
+                   + scanSection('dev_dependencies')
+                   + scanSection('dependency_overrides');
+
+  if (totalDupes == 0) {
+    print('No duplicate keys detected in pubspec.yaml');
+    exit(0);
+  } else {
+    exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- dedupe pubspec dependencies
- add script to catch duplicate dependency keys and run pub get
- add CI workflow to run validation

## Testing
- `bash scripts/validate.sh` *(fails: dart: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68979877cfdc832bbf27e183d630377c