### PR TITLE
feat(theme+nav): align bottom nav and color scheme to Diaspora Pulse × Global Roots

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,14 +52,14 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Consumer<ThemeProvider>(
-      builder: (context, themeProvider, _) {
+      builder: (context, _, __) {
         return MaterialApp(
           title: 'Fouta',
 
           // Use the Material 3 themed definitions for light and dark modes
           theme: AppTheme.light(),
           darkTheme: AppTheme.dark(),
-          themeMode: themeProvider.isDarkMode ? ThemeMode.dark : ThemeMode.light,
+          themeMode: ThemeMode.system,
 
           home: const SplashScreen(),
         );

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -175,12 +175,33 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
           bottomNavigationBar: NavigationBar(
             selectedIndex: _selectedIndex,
             onDestinationSelected: _onItemTapped,
-            destinations: const [
-              NavigationDestination(icon: Icon(Icons.dynamic_feed_outlined), selectedIcon: Icon(Icons.dynamic_feed), label: 'Feed'),
-              NavigationDestination(icon: Icon(Icons.storefront_outlined),  selectedIcon: Icon(Icons.storefront),  label: 'Lumo'),
-              NavigationDestination(icon: Icon(Icons.groups_outlined),      selectedIcon: Icon(Icons.groups),      label: 'Groups'),
-              NavigationDestination(icon: Icon(Icons.event_outlined),       selectedIcon: Icon(Icons.event),       label: 'Events'),
-              NavigationDestination(icon: Icon(Icons.person_outline),       selectedIcon: Icon(Icons.person),      label: 'Profile'),
+            labelBehavior: NavigationDestinationLabelBehavior.onlyShowSelected,
+            destinations: [
+              NavigationDestination(
+                icon: const Icon(Icons.dynamic_feed_outlined),
+                selectedIcon: const _GradientSelectedIcon(Icons.dynamic_feed),
+                label: 'Feed',
+              ),
+              NavigationDestination(
+                icon: const Icon(Icons.chat_bubble_outline),
+                selectedIcon: const _GradientSelectedIcon(Icons.chat_bubble),
+                label: 'Chat',
+              ),
+              NavigationDestination(
+                icon: const Icon(Icons.event_outlined),
+                selectedIcon: const _GradientSelectedIcon(Icons.event),
+                label: 'Events',
+              ),
+              NavigationDestination(
+                icon: const Icon(Icons.group_outlined),
+                selectedIcon: const _GradientSelectedIcon(Icons.group),
+                label: 'People',
+              ),
+              NavigationDestination(
+                icon: const Icon(Icons.person_outline),
+                selectedIcon: const _GradientSelectedIcon(Icons.person),
+                label: 'Profile',
+              ),
             ],
           ),
           body: Consumer<ConnectivityProvider>(
@@ -270,19 +291,19 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
                           label: Text('Feed'),
                         ),
                         NavigationRailDestination(
-                          icon: Icon(Icons.storefront_outlined),
-                          selectedIcon: Icon(Icons.storefront),
-                          label: Text('Lumo'),
-                        ),
-                        NavigationRailDestination(
-                          icon: Icon(Icons.groups_outlined),
-                          selectedIcon: Icon(Icons.groups),
-                          label: Text('Groups'),
+                          icon: Icon(Icons.chat_bubble_outline),
+                          selectedIcon: Icon(Icons.chat_bubble),
+                          label: Text('Chat'),
                         ),
                         NavigationRailDestination(
                           icon: Icon(Icons.event_outlined),
                           selectedIcon: Icon(Icons.event),
                           label: Text('Events'),
+                        ),
+                        NavigationRailDestination(
+                          icon: Icon(Icons.group_outlined),
+                          selectedIcon: Icon(Icons.group),
+                          label: Text('People'),
                         ),
                         NavigationRailDestination(
                           icon: Icon(Icons.person_outline),
@@ -318,6 +339,42 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
       default:
         return 'Fouta';
     }
+  }
+}
+
+class _GradientSelectedIcon extends StatelessWidget {
+  final IconData icon;
+  const _GradientSelectedIcon(this.icon);
+
+  @override
+  Widget build(BuildContext context) {
+    const g1 = Color(0xFF7ED6A0); // pastel green
+    const g2 = Color(0xFFF5D98B); // pastel gold
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        // subtle glow
+        Container(
+          width: 36,
+          height: 36,
+          decoration: const BoxDecoration(
+            shape: BoxShape.circle,
+            boxShadow: [
+              BoxShadow(color: Color(0x337ED6A0), blurRadius: 12, spreadRadius: 1),
+            ],
+          ),
+        ),
+        ShaderMask(
+          blendMode: BlendMode.srcIn,
+          shaderCallback: (Rect bounds) => const LinearGradient(
+            colors: [g1, g2],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ).createShader(bounds),
+          child: Icon(icon, size: 28, color: Colors.white),
+        ),
+      ],
+    );
   }
 }
 

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,58 +1,69 @@
 import 'package:flutter/material.dart';
-import 'tokens.dart';
 
-/// Centralised theme configuration using Material 3.
 class AppTheme {
-  // Brand colours
-  static const Color _primary = Color(0xFF3C7548);
-  static const Color _secondary = Color(0xFFF4D87B);
-  static const Color _error = Color(0xFFD9534F);
-
-  static final ColorScheme lightColorScheme = ColorScheme.fromSeed(
-    seedColor: _primary,
-    brightness: Brightness.light,
-  ).copyWith(
-    primary: _primary,
-    secondary: _secondary,
-    error: _error,
-    background: const Color(0xFFF7F5EF),
-    surface: AppColors.white,
-    onPrimary: AppColors.white,
-    onSecondary: AppColors.black,
-    onBackground: const Color(0xFF333333),
-    onSurface: const Color(0xFF333333),
-  );
-
-  static final ColorScheme darkColorScheme = ColorScheme.fromSeed(
-    seedColor: _primary,
-    brightness: Brightness.dark,
-  ).copyWith(
-    primary: const Color(0xFF2A4930),
-    secondary: const Color(0xFFB38A40),
-    error: _error,
-    background: const Color(0xFF1F2620),
-    surface: const Color(0xFF2D362D),
-    onPrimary: AppColors.white,
-    onSecondary: AppColors.black,
-    onBackground: const Color(0xFFE5E5E5),
-    onSurface: const Color(0xFFE5E5E5),
-  );
-
   static ThemeData light() {
+    const primary = Color(0xFF7ED6A0); // pastel green
+    const secondary = Color(0xFFF5D98B); // pastel gold
+    const tertiary = Color(0xFF2D3A8C); // deep indigo
+    const coral = Color(0xFFE85A5A); // coral red
+
+    final scheme = const ColorScheme.light(
+      primary: primary,
+      onPrimary: Colors.black,
+      secondary: secondary,
+      onSecondary: Colors.black,
+      tertiary: tertiary,
+      onTertiary: Colors.white,
+      error: coral,
+      onError: Colors.white,
+      background: Color(0xFFF7F9F8),
+      onBackground: Color(0xFF0D1215),
+      surface: Colors.white,
+      onSurface: Color(0xFF111418),
+    );
+
     return ThemeData(
       useMaterial3: true,
-      colorScheme: lightColorScheme,
-      scaffoldBackgroundColor: lightColorScheme.background,
-      fontFamily: 'Inter',
+      colorScheme: scheme,
+      navigationBarTheme: NavigationBarThemeData(
+        // We handle the glow/gradient in selectedIcon; disable the default pill.
+        indicatorColor: Colors.transparent,
+        iconTheme: MaterialStateProperty.resolveWith((states) {
+          return IconThemeData(size: states.contains(MaterialState.selected) ? 28 : 26);
+        }),
+        labelTextStyle: MaterialStateProperty.all(const TextStyle(fontWeight: FontWeight.w600)),
+      ),
     );
   }
 
   static ThemeData dark() {
+    const primary = Color(0xFF3BAF7C);  // emerald
+    const secondary = Color(0xFFE1C376); // gold
+    const tertiary = Color(0xFF8791C5);  // muted indigo
+    const coral = Color(0xFFE2726E);     // coral
+
+    final scheme = const ColorScheme.dark(
+      primary: primary,
+      onPrimary: Colors.black,
+      secondary: secondary,
+      onSecondary: Color(0xFF1E1800),
+      tertiary: tertiary,
+      onTertiary: Color(0xFF0B1024),
+      error: coral,
+      onError: Colors.black,
+      background: Color(0xFF0B1A20), // deep teal/indigo background
+      onBackground: Color(0xFFE6ECEF),
+      surface: Color(0xFF0F2233),
+      onSurface: Color(0xFFE4E8EA),
+    );
+
     return ThemeData(
       useMaterial3: true,
-      colorScheme: darkColorScheme,
-      scaffoldBackgroundColor: darkColorScheme.background,
-      fontFamily: 'Inter',
+      colorScheme: scheme,
+      navigationBarTheme: const NavigationBarThemeData(
+        indicatorColor: Colors.transparent,
+      ),
     );
   }
 }
+


### PR DESCRIPTION
## Summary
- implement new pastel green/gold themed `AppTheme` for light and dark schemes
- rework bottom navigation (and rail) to Feed, Chat, Events, People, Profile with gradient selected icons
- use `AppTheme` in `main.dart` with system theme mode

## Testing
- `dart format .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689889183c14832ba211b6cae2448409