### PR TITLE
[Fix] Theme: CardThemeData/DialogThemeData type compatibility

### DIFF
--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -33,8 +33,8 @@ class AppTheme {
         foregroundColor: scheme.onSurface,
         surfaceTintColor: Colors.transparent,
       ),
-      cardTheme: const CardTheme(surfaceTintColor: Colors.transparent),
-      dialogTheme: const DialogTheme(surfaceTintColor: Colors.transparent),
+      cardTheme: const CardThemeData(surfaceTintColor: Colors.transparent),
+      dialogTheme: const DialogThemeData(surfaceTintColor: Colors.transparent),
       bottomSheetTheme: const BottomSheetThemeData(surfaceTintColor: Colors.transparent),
       navigationBarTheme: NavigationBarThemeData(
         backgroundColor: scheme.surface,
@@ -76,8 +76,8 @@ class AppTheme {
         foregroundColor: scheme.onSurface,
         surfaceTintColor: Colors.transparent,
       ),
-      cardTheme: const CardTheme(surfaceTintColor: Colors.transparent),
-      dialogTheme: const DialogTheme(surfaceTintColor: Colors.transparent),
+      cardTheme: const CardThemeData(surfaceTintColor: Colors.transparent),
+      dialogTheme: const DialogThemeData(surfaceTintColor: Colors.transparent),
       bottomSheetTheme: const BottomSheetThemeData(surfaceTintColor: Colors.transparent),
       navigationBarTheme: NavigationBarThemeData(
         backgroundColor: scheme.surface,


### PR DESCRIPTION
## Summary
- switch CardTheme/DialogTheme to CardThemeData/DialogThemeData for compatibility with current Flutter SDK

## Testing
- `dart format .` *(command not found)*
- `flutter analyze` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898a26de570832b8c41738e9511ce95