### PR TITLE
feat(stories+theme+docs): add video capture, polish light mode, add brand tokens/guardrails & contrast CI

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -17,3 +17,6 @@ jobs:
         run: |
           chmod +x scripts/validate.sh
           bash scripts/validate.sh
+      - name: Contrast check
+        run: |
+          dart run tool/contrast_check.dart

--- a/brand/brand-guide.md
+++ b/brand/brand-guide.md
@@ -1,26 +1,13 @@
-# Fouta App Brand Guide (v1)
+# Fouta Brand & Design Guide (v1)
+(Short, friendly; human-readable)
+- Identity: Friendly, modern, rooted in African & diaspora heritage.
+- Navigation (bottom): Feed • Chat • Events • People • Profile (exact labels/order).
+- Colors (Light): Primary #7ED6A0, Secondary #F5D98B, Tertiary #2D3A8C, Error #E85A5A, Background #F7F9F8, Surface #FFFFFF.
+- Colors (Dark): Primary #3BAF7C, Secondary #E1C376, Tertiary #8791C5, Error #E2726E, Background #0E1512, Surface #101D15.
+- Gradients: primaryGlow = #7ED6A0 → #F5D98B (selected nav icons, story rings).
+- Type: Inter; titles SemiBold; body Regular.
+- Motion: 120/200/300ms (fast/standard/large).
+- Accessibility: Tap ≥48dp; follow system light/dark; AA contrast on text.
+- Stories: Tap = photo; Press & hold = video (max 15s); swipe to navigate; press & hold on viewer = pause.
+(Aligned to Diaspora Pulse × Global Roots concept.) 
 
-## Colors
-
-### Light Theme
-- Primary: #7ED6A0
-- Secondary: #F5D98B
-- Complementary: #2D3A8C
-- Accent: #E85A5A
-- Background: #F7F9F8
-- Surface: #FFFFFF
-
-### Dark Theme
-- Primary: #3BAF7C
-- Secondary: #E1C376
-- Complementary: #8791C5
-- Accent: #E2726E
-- Background: #0E1512
-- Surface: #101D15
-
-## Navigation
-1. Feed
-2. Chat
-3. Events
-4. People
-5. Profile

--- a/brand/components.md
+++ b/brand/components.md
@@ -1,10 +1,9 @@
-# Component Rules (Brand v1)
+# Components & Behavior (v1)
+- Bottom Nav: 5 items; selected icon uses primaryGlow gradient; labels show on selection; animation unchanged.
+- Stories Tray: first tile "Your Story" with gradient ring; tapping opens camera; long-press for video; 15s cap; progress ring during recording.
+- Story Viewer: tap right/left to advance/rewind; press & hold to pause; swipe down to dismiss.
+- Post Card: airy layout; action bar icons + counts; subtle reaction burst on like.
+- Event Card: gradient overlay for text legibility; large Join button (gold/coral).
+- Chat: group header may use muted gradient; invite modal uses pastel backgrounds; selected items get gold outline.
+- Accessibility: min 48dp targets; content resizes to 200% text scale; AA contrast.
 
-- **Buttons**
-  - Use primary color (#7ED6A0 light / #3BAF7C dark).
-  - Danger buttons use #E85A5A (light) or #E2726E (dark).
-- **Cards**
-  - Surface color on background (#F7F9F8 light / #0E1512 dark).
-- **Navigation Bar**
-  - Order items: Feed, Chat, Events, People, Profile.
-  - Highlight the active item with the primary color.

--- a/brand/prompts/ai-guardrails.md
+++ b/brand/prompts/ai-guardrails.md
@@ -1,8 +1,10 @@
-# AI Guardrails (Brand v1)
+# AI Guardrails (Fouta)
+- Do not change bottom nav order/labels: Feed, Chat, Events, People, Profile.
+- Follow system appearance; do not force dark or light by default.
+- Use Material 3; use ColorScheme roles ONLY (no hard-coded Colors.*).
+- Keep component surfaceTintColor transparent unless specifically needed.
+- Gradients are limited to: selected nav icon glow; story ring; subtle photo overlays.
+- Stories: tap = photo; long-press = video (≤15s); pass captured media to composer.
+- Any new component must use tokens in /brand/tokens.json; if a color/token is missing, add it there first.
+- Check AA contrast for text; run scripts/validate.sh before PR.
 
-- Use only the approved palette:
-  - Light: #7ED6A0, #F5D98B, #2D3A8C, #E85A5A, background #F7F9F8, surface #FFFFFF
-  - Dark: #3BAF7C, #E1C376, #8791C5, #E2726E, background #0E1512, surface #101D15
-- Keep navigation ordered: Feed, Chat, Events, People, Profile.
-- Maintain a friendly and concise tone in all responses.
-- Avoid introducing new colors or navigation labels.

--- a/brand/tokens.json
+++ b/brand/tokens.json
@@ -1,12 +1,20 @@
 {
-  "color": {
+  "version": 2,
+  "nav": ["Feed", "Chat", "Events", "People", "Profile"],
+  "colors": {
     "light": {
       "primary": "#7ED6A0",
       "secondary": "#F5D98B",
       "tertiary": "#2D3A8C",
       "error": "#E85A5A",
       "background": "#F7F9F8",
-      "surface": "#FFFFFF"
+      "surface": "#FFFFFF",
+      "onPrimary": "#000000",
+      "onSecondary": "#000000",
+      "onTertiary": "#FFFFFF",
+      "onError": "#000000",
+      "onSurface": "#111418",
+      "onBackground": "#111418"
     },
     "dark": {
       "primary": "#3BAF7C",
@@ -14,8 +22,35 @@
       "tertiary": "#8791C5",
       "error": "#E2726E",
       "background": "#0E1512",
-      "surface": "#101D15"
+      "surface": "#101D15",
+      "onPrimary": "#000000",
+      "onSecondary": "#1E1800",
+      "onTertiary": "#0B1024",
+      "onError": "#000000",
+      "onSurface": "#E4E8EA",
+      "onBackground": "#E6ECEF"
+    },
+    "gradients": {
+      "primaryGlow": ["#7ED6A0", "#F5D98B"]
     }
   },
-  "navigation": ["Feed", "Chat", "Events", "People", "Profile"]
+  "typography": {
+    "family": "Inter",
+    "titleLarge": 22,
+    "titleMedium": 18,
+    "bodyMedium": 14,
+    "labelMedium": 12
+  },
+  "motion": { "fast": 120, "standard": 200, "large": 300 },
+  "rules": {
+    "themeModeDefault": "system",
+    "noHardcodedColors": true,
+    "useMaterial3": true
+  },
+  "storyCapture": {
+    "maxVideoSeconds": 15,
+    "tapPhoto": true,
+    "longPressVideo": true
+  }
 }
+

--- a/lib/screens/create_post_screen.dart
+++ b/lib/screens/create_post_screen.dart
@@ -21,6 +21,9 @@ class CreatePostScreen extends StatefulWidget {
   final String? initialContent;
   final String? initialMediaUrl;
   final String? initialMediaType;
+  final String? initialImagePath;
+  final String? initialVideoPath;
+  final bool isStory;
 
   const CreatePostScreen({
     super.key,
@@ -28,6 +31,9 @@ class CreatePostScreen extends StatefulWidget {
     this.initialContent,
     this.initialMediaUrl,
     this.initialMediaType,
+    this.initialImagePath,
+    this.initialVideoPath,
+    this.isStory = false,
   });
 
   @override
@@ -74,6 +80,20 @@ class _CreatePostScreenState extends State<CreatePostScreen> {
           }
         ];
       }
+    }
+    if (widget.initialImagePath != null) {
+      final file = XFile(widget.initialImagePath!);
+      _selectedMediaFiles.add(file);
+      _mediaTypesList.add('image');
+      _videoAspectRatios.add(null);
+      _selectedMediaBytesList.add(null);
+    }
+    if (widget.initialVideoPath != null) {
+      final file = XFile(widget.initialVideoPath!);
+      _selectedMediaFiles.add(file);
+      _mediaTypesList.add('video');
+      _videoAspectRatios.add(null);
+      _selectedMediaBytesList.add(null);
     }
   }
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -21,6 +21,7 @@ import 'package:flutter/widgets.dart' show ScrollDirection, AutomaticKeepAliveCl
 import 'package:fouta_app/main.dart'; // Import APP_ID
 import 'package:fouta_app/screens/chat_screen.dart';
 import 'package:fouta_app/screens/create_post_screen.dart';
+import 'package:fouta_app/screens/story_camera_screen.dart';
 import 'package:fouta_app/screens/new_chat_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:fouta_app/services/connectivity_provider.dart';
@@ -725,13 +726,28 @@ class _FeedTabState extends State<FeedTab> with AutomaticKeepAliveClientMixin {
                       child: StoriesTray(
                         currentUserId:
                             FirebaseAuth.instance.currentUser?.uid ?? '',
-                        onAdd: () {
-                          Navigator.push(
+                        onAdd: () async {
+                          final result = await Navigator.push(
                             context,
                             MaterialPageRoute(
-                              builder: (_) => const CreatePostScreen(),
-                            ),
+                                builder: (_) => const StoryCameraScreen()),
                           );
+                          if (result is Map &&
+                              result['path'] is String &&
+                              (result['path'] as String).isNotEmpty) {
+                            final path = result['path'] as String;
+                            final isVideo = result['type'] == 'video';
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) => CreatePostScreen(
+                                  initialImagePath: isVideo ? null : path,
+                                  initialVideoPath: isVideo ? path : null,
+                                  isStory: true,
+                                ),
+                              ),
+                            );
+                          }
                         },
                       ),
                     ),

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -5,8 +5,8 @@ class AppTheme {
   static ThemeData light() {
     const primary = Color(0xFF7ED6A0); // pastel green
     const secondary = Color(0xFFF5D98B); // pastel gold
-    const tertiary = Color(0xFF2D3A8C); // deep indigo (accent)
-    const coral = Color(0xFFE85A5A); // coral (accent)
+    const tertiary = Color(0xFF2D3A8C); // deep indigo
+    const coral = Color(0xFFE85A5A); // coral
 
     final scheme = const ColorScheme.light(
       primary: primary,
@@ -16,9 +16,9 @@ class AppTheme {
       tertiary: tertiary,
       onTertiary: Colors.white,
       error: coral,
-      onError: Colors.white,
+      onError: Colors.black,
       background: Color(0xFFF7F9F8),
-      onBackground: Color(0xFF0D1215),
+      onBackground: Color(0xFF111418),
       surface: Colors.white,
       onSurface: Color(0xFF111418),
     );
@@ -38,8 +38,7 @@ class AppTheme {
       bottomSheetTheme: const BottomSheetThemeData(surfaceTintColor: Colors.transparent),
       navigationBarTheme: NavigationBarThemeData(
         backgroundColor: scheme.surface,
-        indicatorColor: Colors.transparent, // keep our custom selected icon animation
-        labelTextStyle: MaterialStateProperty.all(const TextStyle(fontWeight: FontWeight.w600)),
+        indicatorColor: Colors.transparent, // keep custom glow/animation
       ),
     );
   }

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -12,5 +12,8 @@ if ! dart run tool/check_pubspec_dupes.dart | tee build/validation/pubspec_dupes
   exit 1
 fi
 
+echo "== Contrast check =="
+dart run tool/contrast_check.dart
+
 echo "== flutter pub get =="
 flutter pub get

--- a/tool/contrast_check.dart
+++ b/tool/contrast_check.dart
@@ -1,0 +1,72 @@
+import 'dart:math';
+
+double _srgbToLinear(int c) {
+  final x = c / 255.0;
+  return x <= 0.04045 ? x / 12.92 : pow((x + 0.055) / 1.055, 2.4).toDouble();
+}
+
+double _luminance(String hex) {
+  hex = hex.replaceAll('#', '');
+  final r = int.parse(hex.substring(0, 2), radix: 16);
+  final g = int.parse(hex.substring(2, 4), radix: 16);
+  final b = int.parse(hex.substring(4, 6), radix: 16);
+  final R = _srgbToLinear(r);
+  final G = _srgbToLinear(g);
+  final B = _srgbToLinear(b);
+  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+}
+
+double contrast(String a, String b) {
+  final L1 = _luminance(a);
+  final L2 = _luminance(b);
+  final hi = max(L1, L2);
+  final lo = min(L1, L2);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+void main() {
+  const light = {
+    'primary': '#7ED6A0',
+    'onPrimary': '#000000',
+    'secondary': '#F5D98B',
+    'onSecondary': '#000000',
+    'surface': '#FFFFFF',
+    'onSurface': '#111418',
+    'error': '#E85A5A',
+    'onError': '#000000',
+  };
+  const dark = {
+    'primary': '#3BAF7C',
+    'onPrimary': '#000000',
+    'secondary': '#E1C376',
+    'onSecondary': '#1E1800',
+    'surface': '#101D15',
+    'onSurface': '#E4E8EA',
+    'error': '#E2726E',
+    'onError': '#000000',
+  };
+
+  final checks = [
+    ['light onPrimary/primary', contrast(light['onPrimary']!, light['primary']!)],
+    ['light onSecondary/secondary', contrast(light['onSecondary']!, light['secondary']!)],
+    ['light onSurface/surface', contrast(light['onSurface']!, light['surface']!)],
+    ['light onError/error', contrast(light['onError']!, light['error']!)],
+    ['dark onPrimary/primary', contrast(dark['onPrimary']!, dark['primary']!)],
+    ['dark onSecondary/secondary', contrast(dark['onSecondary']!, dark['secondary']!)],
+    ['dark onSurface/surface', contrast(dark['onSurface']!, dark['surface']!)],
+    ['dark onError/error', contrast(dark['onError']!, dark['error']!)],
+  ];
+
+  bool fail = false;
+  for (final c in checks) {
+    final ratio = (c[1] as double);
+    if (ratio < 4.5) {
+      fail = true;
+      print('FAIL ${c[0]} contrast ${ratio.toStringAsFixed(2)} < 4.5');
+    } else {
+      print('OK   ${c[0]} contrast ${ratio.toStringAsFixed(2)}');
+    }
+  }
+  if (fail) throw Exception('Contrast check failed');
+}
+


### PR DESCRIPTION
## Summary
- polish light theme surfaces and ensure onError contrast
- enable tap photo & long-press video stories with progress ring
- wire story capture into composer and document brand tokens/guardrails
- add contrast checker tool to CI

## Testing
- `dart format .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `bash scripts/validate.sh` *(fails: dart: command not found)*
- `flutter run -d chrome` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6898adb35b48832ba3123cb6df3341f8