### PR TITLE
fix(bug-report/overlay): remove root report button overlay; wrap with Material; neutral non-blocking viewer scrim

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,10 +17,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 // Use the Diaspora Connection theme instead of the original Baobab theme
 import 'package:fouta_app/theme/app_theme.dart';
 import 'firebase_options.dart';
-import 'package:flutter/foundation.dart';
 import 'utils/log_buffer.dart';
 import 'utils/bug_reporter.dart';
-import 'widgets/report_bug_button.dart';
 import 'dev/panic_dismiss.dart';
 
 // Define a global constant for the app ID.
@@ -75,19 +73,7 @@ class MyApp extends StatelessWidget {
             builder: (context, child) => PanicDismiss(
               child: RepaintBoundary(
                 key: BugReporter.repaintBoundaryKey,
-                child: Stack(
-                  children: [
-                    if (child != null) child,
-                    if (!kReleaseMode && kShowBugFabInDebug)
-                      Positioned(
-                        right: 16,
-                        bottom: 16,
-                        child: ReportBugButton(
-                          child: const Text('🐞'),
-                        ),
-                      ),
-                  ],
-                ),
+                child: child!,
               ),
             ),
 

--- a/lib/widgets/report_bug_button.dart
+++ b/lib/widgets/report_bug_button.dart
@@ -1,27 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:fouta_app/screens/report_bug_screen.dart';
 
-import '../screens/report_bug_screen.dart';
-
-/// Whether to show the floating debug bug button in non-release builds.
-const bool kShowBugFabInDebug = true;
-
-/// Wraps [child] with a tap handler that opens [ReportBugScreen].
 class ReportBugButton extends StatelessWidget {
-  const ReportBugButton({super.key, required this.child});
-
-  final Widget child;
-
+  const ReportBugButton({super.key});
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: () {
-        Navigator.push(
+    final cs = Theme.of(context).colorScheme;
+    return Material(
+      type: MaterialType.transparency,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () => Navigator.push(
           context,
           MaterialPageRoute(builder: (_) => const ReportBugScreen()),
-        );
-      },
-      child: child,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(mainAxisSize: MainAxisSize.min, children: [
+            Icon(Icons.bug_report_outlined, color: cs.onSurface, size: 20),
+            const SizedBox(width: 8),
+            Text('Report a Bug', style: TextStyle(color: cs.onSurface)),
+          ]),
+        ),
+      ),
     );
   }
 }
-


### PR DESCRIPTION
## Summary
- remove global ReportBugButton from `MaterialApp.builder` and keep only panic dismiss & repaint boundary
- wrap report bug button with Material and inkwell for proper theming
- show neutral non-blocking black scrim with a report menu in full-screen media viewer

## Testing
- `apt-get update` *(fails: repository not signed)*
- `flutter clean` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899367b1af0832ba3fa4f3150534c77