### PR TITLE
feat(stories+video+viewer+nav): reliable stories publish; video posts; true fullscreen & swipe-back; playback coordinator; restore nested tabs; bug reporter UX; contrast tune

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,10 +9,7 @@
     <application
         android:label="fouta_app"
         android:name="${applicationName}"
-        android:icon="@mipmap/launcher_icon">
-	android:name="io.flutter.app.FlutterApplication"
-        android:label="fouta_app"
-        android:icon="@mipmap/ic_launcher"
+        android:icon="@mipmap/launcher_icon"
         android:enableOnBackInvokedCallback="true">
         <activity
             android:name=".MainActivity"

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -428,21 +428,16 @@ class _ChatScreenState extends State<ChatScreen> {
     switch (mediaType) {
       case 'image':
         return GestureDetector(
-          onTap: () => Navigator.push(
+          onTap: () => FullScreenMediaViewer.open(
             context,
-            MaterialPageRoute(
-              builder: (_) => FullScreenMediaViewer(
-                items: [
-                  MediaItem(
-                    id: mediaUrl,
-                    type: MediaType.image,
-                    url: mediaUrl,
-                  ),
-                ],
-                initialIndex: 0,
+            [
+              MediaItem(
+                id: mediaUrl,
+                type: MediaType.image,
+                url: mediaUrl,
               ),
-              fullscreenDialog: true,
-            ),
+            ],
+            initialIndex: 0,
           ),
           child: CachedNetworkImage(
             imageUrl: mediaUrl,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -126,17 +126,14 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
     }
   }
 
-  Widget _buildOffstageNavigator(int index, Widget child) {
-    return Offstage(
-      offstage: _selectedIndex != index,
-      child: Navigator(
-        key: _navigatorKeys[index],
-        onGenerateRoute: (routeSettings) {
-          return MaterialPageRoute(
-            builder: (context) => child,
-          );
-        },
-      ),
+  Widget _buildTabNavigator(int index, Widget child) {
+    return Navigator(
+      key: _navigatorKeys[index],
+      onGenerateRoute: (routeSettings) {
+        return MaterialPageRoute(
+          builder: (context) => child,
+        );
+      },
     );
   }
   
@@ -163,9 +160,15 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
 
     return WillPopScope(
       onWillPop: () async {
+        final currentNavigator =
+            _navigatorKeys[_selectedIndex].currentState;
+        if (currentNavigator != null && currentNavigator.canPop()) {
+          currentNavigator.pop();
+          return false;
+        }
         if (_selectedIndex != 0) {
           setState(() => _selectedIndex = 0);
-          return false; // handled here; do not pop the route
+          return false;
         }
         return true; // on first tab → allow system back
       },
@@ -244,16 +247,16 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
                 body: IndexedStack(
                   index: _selectedIndex,
                   children: <Widget>[
-                    _buildOffstageNavigator(
+                    _buildTabNavigator(
                         0, FeedTab(setNavBarVisibility: _setNavBarVisibility)),
-                    _buildOffstageNavigator(
+                    _buildTabNavigator(
                         1,
                         ChatsTab(
                             setNavBarVisibility: _setNavBarVisibility,
                             setShowNewChatFab: _setShowNewChatFab)),
-                    _buildOffstageNavigator(2, const EventsListScreen()),
-                    _buildOffstageNavigator(3, const PeopleTab()),
-                    _buildOffstageNavigator(
+                    _buildTabNavigator(2, const EventsListScreen()),
+                    _buildTabNavigator(3, const PeopleTab()),
+                    _buildTabNavigator(
                         4, ProfileScreen(userId: currentUser?.uid ?? '')),
                   ],
                 ),

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -367,21 +367,16 @@ class _ProfileScreenState extends State<ProfileScreen>
               if (_isEditing) {
                 _pickProfileImage();
               } else if (_currentProfileImageUrl.isNotEmpty) {
-                Navigator.push(
+                FullScreenMediaViewer.open(
                   context,
-                  MaterialPageRoute(
-                    builder: (context) => FullScreenMediaViewer(
-                      items: [
-                        MediaItem(
-                          id: 'profile-image',
-                          type: MediaType.image,
-                          url: _currentProfileImageUrl,
-                        ),
-                      ],
-                      initialIndex: 0,
+                  [
+                    MediaItem(
+                      id: 'profile-image',
+                      type: MediaType.image,
+                      url: _currentProfileImageUrl,
                     ),
-                    fullscreenDialog: true,
-                  ),
+                  ],
+                  initialIndex: 0,
                 );
               }
             } : null,

--- a/lib/screens/report_bug_screen.dart
+++ b/lib/screens/report_bug_screen.dart
@@ -14,12 +14,24 @@ class ReportBugScreen extends StatefulWidget {
 class _ReportBugScreenState extends State<ReportBugScreen> {
   Uint8List? _screenshot;
   final TextEditingController _controller = TextEditingController();
+  final FocusNode _focusNode = FocusNode();
   bool _sending = false;
 
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _capture());
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final bytes = await BugReporter.capturePng(context);
+      if (!mounted) return;
+      setState(() => _screenshot = bytes);
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
   }
 
   Future<void> _capture() async {
@@ -59,6 +71,7 @@ class _ReportBugScreenState extends State<ReportBugScreen> {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
+      resizeToAvoidBottomInset: true,
       appBar: AppBar(title: const Text('Report a Bug')),
       body: ListView(
         padding: const EdgeInsets.all(16),
@@ -76,6 +89,7 @@ class _ReportBugScreenState extends State<ReportBugScreen> {
             ),
           TextField(
             controller: _controller,
+            focusNode: _focusNode,
             maxLines: 5,
             decoration: const InputDecoration(
               labelText: 'Description',

--- a/lib/services/playback_coordinator.dart
+++ b/lib/services/playback_coordinator.dart
@@ -1,0 +1,43 @@
+import 'package:media_kit/media_kit.dart';
+
+/// Coordinates audio/video playback so that only one [Player] is active
+/// at a time across the app.
+class PlaybackCoordinator {
+  PlaybackCoordinator._();
+  static final PlaybackCoordinator instance = PlaybackCoordinator._();
+
+  final Set<Player> _players = {};
+  Player? _active;
+
+  /// Registers a [Player] with the coordinator.
+  void register(Player player) {
+    _players.add(player);
+  }
+
+  /// Unregisters a [Player].
+  void unregister(Player player) {
+    _players.remove(player);
+    if (_active == player) {
+      _active = null;
+    }
+  }
+
+  /// Sets the given [player] as active and pauses any previously active player.
+  void setActive(Player player) {
+    if (_active == player) return;
+    _active?.pause();
+    _active = player;
+  }
+
+  /// Pause all registered players.
+  void pauseAll() {
+    for (final p in _players) {
+      try {
+        p.pause();
+      } catch (_) {
+        // ignore errors from disposed players
+      }
+    }
+    _active = null;
+  }
+}

--- a/lib/widgets/media/post_media.dart
+++ b/lib/widgets/media/post_media.dart
@@ -44,15 +44,8 @@ class PostMedia extends StatelessWidget {
     return Semantics(
       label: first.type == MediaType.image ? 'Image preview' : 'Video preview',
       child: GestureDetector(
-        onTap: () => Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (_) => FullScreenMediaViewer(
-              items: media,
-              initialIndex: 0,
-            ),
-            fullscreenDialog: true,
-          ),
-        ),
+        onTap: () =>
+            FullScreenMediaViewer.open(context, media, initialIndex: 0),
         child: AspectRatio(
           aspectRatio: aspect,
           child: Hero(

--- a/lib/widgets/post_card_widget.dart
+++ b/lib/widgets/post_card_widget.dart
@@ -637,20 +637,12 @@ class _PostCardWidgetState extends State<PostCardWidget> {
     }
     return GestureDetector(
       onTap: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => FullScreenMediaViewer(
-              items: attachments
-                  .whereType<Map<String, dynamic>>()
-                  .map(MediaItem.fromMap)
-                  .whereType<MediaItem>()
-                  .toList(),
-              initialIndex: 0,
-            ),
-            fullscreenDialog: true,
-          ),
-        );
+        final items = attachments
+            .whereType<Map<String, dynamic>>()
+            .map(MediaItem.fromMap)
+            .whereType<MediaItem>()
+            .toList();
+        FullScreenMediaViewer.open(context, items, initialIndex: 0);
       },
       child: Stack(
         children: [

--- a/lib/widgets/stories/stories_tray.dart
+++ b/lib/widgets/stories/stories_tray.dart
@@ -92,12 +92,14 @@ class StoriesTray extends StatelessWidget {
                   ),
                 ),
                 child: ClipOval(
-                  child: Image.network(
-                    thumb ?? '',
-                    fit: BoxFit.cover,
-                    errorBuilder: (context, _, __) =>
-                        Container(color: cs.surfaceVariant),
-                  ),
+                  child: thumb != null
+                      ? Image.network(
+                          thumb,
+                          fit: BoxFit.cover,
+                          errorBuilder: (context, _, __) =>
+                              Container(color: cs.surfaceVariant),
+                        )
+                      : Container(color: cs.surfaceVariant),
                 ),
               ),
               if (isMe && (!showAddFirst || onAdd == null))

--- a/lib/widgets/video_player_widget.dart
+++ b/lib/widgets/video_player_widget.dart
@@ -279,22 +279,17 @@ class _DynamicVideoControls extends StatelessWidget {
                   icon: Icon(Icons.fullscreen, color: Theme.of(context).colorScheme.onPrimary),
                   onPressed: () {
                     player.pause();
-                    Navigator.push(
+                    FullScreenMediaViewer.open(
                       context,
-                      MaterialPageRoute(
-                        builder: (context) => FullScreenMediaViewer(
-                          items: [
-                            MediaItem(
-                              id: videoUrl,
-                              type: MediaType.video,
-                              url: videoUrl,
-                              duration: player.state.duration,
-                            ),
-                          ],
-                          initialIndex: 0,
+                      [
+                        MediaItem(
+                          id: videoUrl,
+                          type: MediaType.video,
+                          url: videoUrl,
+                          duration: player.state.duration,
                         ),
-                        fullscreenDialog: true,
-                      ),
+                      ],
+                      initialIndex: 0,
                     );
                   },
                 ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   photo_view: ^0.14.0
   video_player: ^2.8.2
   subtitle_wrapper_package: ^2.0.0
+  uuid: ^3.0.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add playback coordinator to pause competing players
- root-level fullscreen viewer with swipe-back and overlay back button
- publish story slides to storage and return DTO with expiry
- improve bug reporter capture and focus handling
- retain per-tab navigation stacks and updated back handling

## Testing
- `dart format .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68993de536f4832b9b83bbb6be5a9963