### PR TITLE
fix(route-observer): remove invalid didPopNext override; pause playback on push/pop/replace/remove

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -70,7 +70,7 @@ class MyApp extends StatelessWidget {
             theme: AppTheme.light(),
             darkTheme: AppTheme.dark(),
             themeMode: controller.themeMode,
-            navigatorObservers: [playbackRouteObserver],
+            navigatorObservers: [PlaybackRouteObserver()],
 
             builder: (context, child) => PanicDismiss(
               child: RepaintBoundary(

--- a/lib/services/playback_route_observer.dart
+++ b/lib/services/playback_route_observer.dart
@@ -1,25 +1,28 @@
 import 'package:flutter/material.dart';
-
 import 'playback_coordinator.dart';
 
-/// Route observer that pauses all media players whenever a new page is pushed
-/// or when returning to a previous page.
-class PlaybackRouteObserver extends RouteObserver<PageRoute<dynamic>> {
-  void _pauseAll() => PlaybackCoordinator.instance.pauseAll();
-
+class PlaybackRouteObserver extends NavigatorObserver {
+  void _pauseAll() {
+    try { PlaybackCoordinator.instance.pauseAll(); } catch (_) {}
+  }
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPush(route, previousRoute);
-    if (route is PageRoute) _pauseAll();
+    _pauseAll();
   }
-
   @override
-  void didPopNext(Route<dynamic> nextRoute, Route<dynamic>? previousRoute) {
-    super.didPopNext(nextRoute, previousRoute);
-    if (nextRoute is PageRoute) _pauseAll();
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    _pauseAll();
+  }
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    _pauseAll();
+  }
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didRemove(route, previousRoute);
+    _pauseAll();
   }
 }
-
-/// Global instance used by [MaterialApp.navigatorObservers].
-final playbackRouteObserver = PlaybackRouteObserver();
-


### PR DESCRIPTION
## Summary
- replace `PlaybackRouteObserver` to use `NavigatorObserver`
- pause playback when routes push, pop, replace, or remove
- register `PlaybackRouteObserver` with `MaterialApp`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68996565611c832b809243672e61b6e8