### PR TITLE
fix(stories wiring): define _stories in FeedTab; remove const from SettableMetadata; import debugPrint

### DIFF
--- a/lib/features/stories/data/story_repository.dart
+++ b/lib/features/stories/data/story_repository.dart
@@ -1,7 +1,9 @@
 import 'dart:io';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_storage/firebase_storage.dart';
+import 'package:firebase_storage/firebase_storage.dart'
+    show FirebaseStorage, SettableMetadata;
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:uuid/uuid.dart';
 import 'package:video_thumbnail/video_thumbnail.dart';
 import 'package:video_player/video_player.dart';
@@ -52,7 +54,7 @@ class StoryRepository {
             .child('stories/$userId/${slideId}_thumb.jpg');
         await thumbRef.putData(
           thumbData,
-          const SettableMetadata(contentType: 'image/jpeg'),
+          SettableMetadata(contentType: 'image/jpeg'),
         );
         thumbUrl = await thumbRef.getDownloadURL();
       }

--- a/lib/screens/create_post_screen.dart
+++ b/lib/screens/create_post_screen.dart
@@ -333,7 +333,10 @@ class _CreatePostScreenState extends State<CreatePostScreen> {
           );
           if (thumbData != null) {
             final thumbRef = FirebaseStorage.instance.ref().child('videos/${user.uid}/${baseName}_thumb.jpg');
-            await thumbRef.putData(thumbData, const SettableMetadata(contentType: 'image/jpeg'));
+            await thumbRef.putData(
+              thumbData,
+              SettableMetadata(contentType: 'image/jpeg'),
+            );
             thumbUrl = await thumbRef.getDownloadURL();
           }
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -500,6 +500,9 @@ class _FeedTabState extends State<FeedTab> with AutomaticKeepAliveClientMixin {
   final VideoCacheService _videoCacheService = VideoCacheService();
   int _lastPrecachedIndex = 0;
 
+  // Stories currently loaded in the feed
+  List<Story> _stories = [];
+
 
   bool _isDataSaverOn = true;
   bool _isOnMobileData = false;


### PR DESCRIPTION
## Summary
- add `_stories` list to feed tab so StoriesTray gets data
- drop `const` from `SettableMetadata` calls
- import `debugPrint` for story repository

## Testing
- `flutter clean` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a0574bf1c832bbfdba7ab437f6bed