### PR TITLE
Fix stories tray missing newly posted story

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -753,7 +753,22 @@ class _FeedTabState extends State<FeedTab> with AutomaticKeepAliveClientMixin {
                             });
                             StoryRepository().fetchStoriesFeed().then((s) {
                               if (mounted) {
-                                setState(() => _stories = s);
+                                setState(() {
+                                  // Merge fetched stories with local state so that
+                                  // the newly created story isn't lost if the
+                                  // backend query hasn't caught up yet.
+                                  final merged = List<Story>.from(_stories);
+                                  for (final fetched in s) {
+                                    final existingIndex = merged
+                                        .indexWhere((st) => st.authorId == fetched.authorId);
+                                    if (existingIndex >= 0) {
+                                      merged[existingIndex] = fetched;
+                                    } else {
+                                      merged.add(fetched);
+                                    }
+                                  }
+                                  _stories = merged;
+                                });
                               }
                             });
                           }


### PR DESCRIPTION
## Summary
- ensure the newly created story stays in the tray even if the backend feed hasn't updated

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a095a3f54832b9885bdfeca8ec449