### PR TITLE
fix: handle content URIs in post creator

### DIFF
--- a/lib/screens/create_post_screen.dart
+++ b/lib/screens/create_post_screen.dart
@@ -154,25 +154,42 @@ class _CreatePostScreenState extends State<CreatePostScreen> {
     // Validate video size for videos on non-web platforms and compute aspect ratio
     double? aspectRatio;
     if (isVideo && !kIsWeb) {
-      final fileSize = File(pickedFile.path).lengthSync();
+      int fileSize;
+      if (pickedFile.path.startsWith('content://')) {
+        try {
+          fileSize = await pickedFile.length();
+        } catch (e) {
+          _showMessage('Failed to read video size: $e');
+          return;
+        }
+      } else {
+        fileSize = File(pickedFile.path).lengthSync();
+      }
       if (fileSize > _maxVideoFileSize) {
         _showMessage('Video is too large. Users are currently limited to 500 MB.');
         return;
       }
       final player = Player();
-      // Open the video without autoplay to avoid background audio during
-      // metadata extraction.  `play: false` prevents the player from
-      // immediately starting playback which previously caused the selected
-      // video's audio to play even though the user had not yet posted it.
-      // The `file://` scheme ensures `media_kit` reads the local temp file
-      // rather than treating it as a remote URI.
-      final uri = Uri.file(pickedFile.path).toString();
-      await player.open(Media(uri), play: false);
-      await player.stream.width.firstWhere((width) => width != null);
-      final width = player.state.width;
-      final height = player.state.height;
-      if (width != null && height != null && height > 0) {
-        aspectRatio = width / height;
+      try {
+        // Open the video without autoplay to avoid background audio during
+        // metadata extraction.  `play: false` prevents the player from
+        // immediately starting playback which previously caused the selected
+        // video's audio to play even though the user had not yet posted it.
+        // Using `Uri.parse` allows `media_kit` to open `content://` URIs as well
+        // as file paths.
+        final uri = Uri.parse(pickedFile.path).toString();
+        await player.open(Media(uri), play: false);
+        await player.stream.width.firstWhere((width) => width != null);
+        final width = player.state.width;
+        final height = player.state.height;
+        if (width != null && height != null && height > 0) {
+          aspectRatio = width / height;
+        }
+      } catch (e) {
+        _showMessage('Failed to read video metadata: $e');
+        return;
+      } finally {
+        await player.dispose();
       }
     }
 


### PR DESCRIPTION
## Summary
- handle `content://` URIs when picking video so file size and metadata can be read
- use `Uri.parse` for `media_kit` and dispose player after metadata extraction
- surface errors via snackbar to avoid crashes

## Risks
- **Incorrect URI detection**: may not cover all edge cases; tested with path prefix check.
- **Video metadata failures**: could still fail for unsupported formats; gracefully handled with snackbar.
- **Performance**: reading size for `content://` may incur extra I/O; mitigated by quick `XFile.length` call.
- **Player disposal**: disposing immediately might miss late stream events; but ensures no leaks.
- **User messaging**: snackbar messages rely on localized strings; current generic text may need refinement.

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `cd functions && npm ci` *(fails: package.json and lock file out of sync)*
- `npm test --if-present`
- `flutter build web --release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b6bb96614832b9bb5899af6070054