### PR TITLE
fix: handle content URIs in chat media picker

### DIFF
--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -219,11 +219,23 @@ class _ChatScreenState extends State<ChatScreen> {
     if (pickedFile != null) {
       // Validate video size for non-web platforms
       if (isVideo && !kIsWeb) {
-        final fileSize = File(pickedFile.path).lengthSync();
-        if (fileSize > _maxVideoFileSize) {
+        try {
+          final fileSize = pickedFile.path.startsWith('content://')
+              ? await pickedFile.length()
+              : File(pickedFile.path).lengthSync();
+
+          if (fileSize > _maxVideoFileSize) {
+            AppSnackBar.show(
+              context,
+              'Video is too large. Users are currently limited to 500 MB.',
+              isError: true,
+            );
+            return;
+          }
+        } catch (e) {
           AppSnackBar.show(
             context,
-            'Video is too large. Users are currently limited to 500 MB.',
+            'Could not access selected file.',
             isError: true,
           );
           return;


### PR DESCRIPTION
## Summary
- handle content URIs in chat media picker to avoid sync length issues
- notify users if selected files can't be accessed

## Testing
- `flutter pub get` *(fails: command not found)*
- `npm ci` *(fails: package.json/package-lock.json mismatch)*
- `npm test --if-present`
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `flutter build web --release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b6bc5f730832bbbf2c02ee5525960