### PR TITLE
feat: add facebook-style post composer

### DIFF
--- a/lib/screens/create_post_screen.dart
+++ b/lib/screens/create_post_screen.dart
@@ -426,6 +426,7 @@ class _CreatePostScreenState extends State<CreatePostScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final userName = FirebaseAuth.instance.currentUser?.displayName ?? 'Fouta';
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.postId == null ? 'Create New Post' : 'Edit Post'),
@@ -453,7 +454,7 @@ class _CreatePostScreenState extends State<CreatePostScreen> {
               controller: _postContentController,
               maxLines: 6,
               decoration: InputDecoration(
-                hintText: 'What\'s on your mind, Fouta?',
+                hintText: "What's on your mind, $userName?",
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12.0),
                 ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -39,6 +39,7 @@ import 'package:fouta_app/widgets/skeletons/feed_skeleton.dart';
 import 'package:fouta_app/utils/snackbar.dart';
 import 'package:fouta_app/models/story.dart';
 import 'package:fouta_app/widgets/system/offline_banner.dart';
+import 'package:fouta_app/widgets/post_composer.dart';
 
 
 class HomeScreen extends StatefulWidget {
@@ -861,6 +862,16 @@ class _FeedTabState extends State<FeedTab> with AutomaticKeepAliveClientMixin {
                 ),
               ),
             ),
+          PostComposer(
+            onCompose: () async {
+              widget.setNavBarVisibility(false);
+              await Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const CreatePostScreen()),
+              );
+              widget.setNavBarVisibility(true);
+            },
+          ),
           FoutaCard(
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
             child: Row(

--- a/lib/widgets/post_composer.dart
+++ b/lib/widgets/post_composer.dart
@@ -1,0 +1,79 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:fouta_app/widgets/fouta_card.dart';
+
+/// A lightweight post composer inspired by Facebook's feed UI.
+/// It uses the current app theme while giving users a familiar way
+/// to start writing a post or attach media.
+class PostComposer extends StatelessWidget {
+  final VoidCallback onCompose;
+  const PostComposer({super.key, required this.onCompose});
+
+  @override
+  Widget build(BuildContext context) {
+    final user = FirebaseAuth.instance.currentUser;
+    final photoUrl = user?.photoURL;
+
+    return FoutaCard(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              CircleAvatar(
+                radius: 20,
+                backgroundImage:
+                    photoUrl != null ? CachedNetworkImageProvider(photoUrl) : null,
+                child: photoUrl == null ? const Icon(Icons.person) : null,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(30),
+                  onTap: onCompose,
+                  child: Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(30),
+                      color: Theme.of(context).colorScheme.surfaceVariant,
+                    ),
+                    child: Text(
+                      "What's on your mind?",
+                      style: TextStyle(
+                        color:
+                            Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          const Divider(height: 1),
+          SizedBox(
+            height: 40,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                TextButton.icon(
+                  onPressed: onCompose,
+                  icon: const Icon(Icons.photo),
+                  label: const Text('Photo'),
+                ),
+                TextButton.icon(
+                  onPressed: onCompose,
+                  icon: const Icon(Icons.videocam),
+                  label: const Text('Video'),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a Facebook-inspired post composer widget using the existing theme
- surface the composer on the home feed for quicker posting
- personalize the post editor placeholder with the current user's name

## Risks
- Composer layout may not scale well on very small screens; verify responsiveness on target devices
- New widget relies on FirebaseAuth user data which could be null; ensure guest sessions handled
- Additional widget in feed could impact initial load time; profile performance
- Placeholder string interpolation may break localization; review when adding i18n
- Added imports may cause conflicts if similar widgets exist; watch for namespace collisions

## Tests
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed lib/screens/home_screen.dart lib/screens/create_post_screen.dart lib/widgets/post_composer.dart` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: package.json and lock file out of sync)*
- `npm test --if-present`
- `flutter build web --release` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689b8e6d1438832b8e3e578d95bafc8f