### PR TITLE
refactor: remove redundant post creation icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Fouta App is a cross-platform Flutter application that integrates Firebase servi
   - Icons: group_add
   - Colors: None
 - `home_screen.dart`
-  - Icons: add_circle_outline, archive_outlined, chat_bubble_outline, event_outlined, home_outlined, info_outline, logout, menu, message, notifications_outlined, people_outlined, person, person_outlined, search, settings_outlined, volume_mute_outlined, wifi_off
+  - Icons: archive_outlined, chat_bubble_outline, event_outlined, home_outlined, info_outline, logout, menu, message, notifications_outlined, people_outlined, person, person_outlined, search, settings_outlined, volume_mute_outlined, wifi_off
   - Colors: blue, green, grey, white
 - `new_chat_screen.dart`
   - Icons: group_add, person

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -248,16 +248,6 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
                       // Keep the app bar visible while scrolling
                       pinned: true,
                       actions: [
-                        IconButton(
-                          icon: const Icon(Icons.add_circle_outline),
-                          tooltip: 'Create Post',
-                          onPressed: () => Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (context) => const CreatePostScreen(),
-                            ),
-                          ),
-                        ),
                         _NotificationsButton(
                             unreadStream: _unreadNotificationsStream),
                         Builder(


### PR DESCRIPTION
## Summary
- remove create post icon from top app bar to avoid duplication
- update icon list in documentation

## Risks
- Users may miss top-level entry point for post creation (mitigated by existing PostComposer widget)
- Potential unseen references to removed icon (mitigated by repo-wide search)
- Navigation expectations could shift without explicit visual cue (mitigated by in-feed composer and Fouta button)

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `(cd functions && npm ci)` *(fails: lock file out of sync)*
- `(cd functions && npm test --if-present)`
- `flutter build web --release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b92046560832bae0938053ffa71dc