### PR TITLE
feat: add double-tap like gesture

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ flutter test
 - 2025-08-14 00:00 UTC – Documented global majority vision and roadmap.
 - 2025-08-12 19:46 UTC – Scaffolded discovery, moderation, growth, analytics, and monetization modules and documented competitive architecture.
 - 2025-08-12 20:09 UTC – Added post bookmarking with a dedicated screen for viewing saved posts.
+- 2025-08-12 20:21 UTC – Added double-tap to like posts for quicker engagement.
 
 ## Contributing
 - Follow the logging and documentation guidelines outlined above.

--- a/lib/widgets/post_card_widget.dart
+++ b/lib/widgets/post_card_widget.dart
@@ -213,6 +213,12 @@ class _PostCardWidgetState extends State<PostCardWidget> {
     }
   }
 
+  void _likeOnDoubleTap() {
+    if (!_isLiked) {
+      _toggleLike();
+    }
+  }
+
   Future<void> _toggleBookmark() async {
     final user = widget.currentUser;
     if (user == null || user.isAnonymous) {
@@ -697,6 +703,7 @@ class _PostCardWidgetState extends State<PostCardWidget> {
             .toList();
         FullScreenMediaViewer.open(context, items, initialIndex: 0);
       },
+      onDoubleTap: _likeOnDoubleTap,
       child: Stack(
         children: [
           thumb,


### PR DESCRIPTION
## Summary
- allow double-tap on post media to like if not already liked
- document double-tap like capability in change log

## Risks
- double-tap may interfere with other gestures on media: mitigated by keeping single tap to open viewer
- users might accidentally like when zooming: mitigated by limiting to media area
- potential performance overhead from added gesture detection: minimal due to lightweight handler
- inconsistent behavior if user double taps rapidly: handled by toggle logic
- possible regression in media viewer opening: single tap logic retained

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: package-lock mismatch)*
- `npm test --if-present`
- `flutter build web --release` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689ba1724e38832b9bc6bb1cfef34459