### PR TITLE
feat: add shorts, marketplace, and AR camera screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ Dedicated feature modules keep the project competitive with larger platforms. Th
 - `unified_settings_screen.dart`
   - Icons: dark_mode_outlined, data_saver_on_outlined, delete_forever_outlined, info_outline, lock_outline, person_outline, privacy_tip_outlined
   - Colors: green, red, white
+- `ar_camera_screen.dart`
+  - Icons: auto_awesome_outlined
+  - Colors: None
+- `marketplace_screen.dart`
+  - Icons: storefront_outlined
+  - Colors: None
+- `shorts_screen.dart`
+  - Icons: play_arrow_outlined
+  - Colors: None
 
 ### Widgets
 
@@ -296,6 +305,7 @@ flutter test
 - 2025-08-12 20:09 UTC – Added post bookmarking with a dedicated screen for viewing saved posts.
 - 2025-08-12 20:21 UTC – Added double-tap to like posts for quicker engagement.
 - 2025-08-12 20:39 UTC – Enabled users to report posts for moderation review.
+- 2025-08-12 20:52 UTC – Added Shorts, Marketplace, and AR Camera stub screens accessible from the navigation drawer.
 
 ## Contributing
 - Follow the logging and documentation guidelines outlined above.

--- a/lib/screens/ar_camera_screen.dart
+++ b/lib/screens/ar_camera_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class ArCameraScreen extends StatelessWidget {
+  const ArCameraScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('AR Camera')),
+      body: const Center(
+        child: Text('AR effects will be available soon.'),
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -41,6 +41,9 @@ import 'package:fouta_app/models/story.dart';
 import 'package:fouta_app/widgets/system/offline_banner.dart';
 import 'package:fouta_app/widgets/post_composer.dart';
 import 'package:fouta_app/screens/bookmarks_screen.dart';
+import 'package:fouta_app/screens/shorts_screen.dart';
+import 'package:fouta_app/screens/marketplace_screen.dart';
+import 'package:fouta_app/screens/ar_camera_screen.dart';
 
 
 class HomeScreen extends StatefulWidget {
@@ -466,6 +469,39 @@ class _AppDrawer extends StatelessWidget {
               Navigator.push(
                 context,
                 MaterialPageRoute(builder: (context) => const BookmarksScreen()),
+              );
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.play_arrow_outlined),
+            title: const Text('Shorts'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const ShortsScreen()),
+              );
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.storefront_outlined),
+            title: const Text('Marketplace'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const MarketplaceScreen()),
+              );
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.auto_awesome_outlined),
+            title: const Text('AR Camera'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const ArCameraScreen()),
               );
             },
           ),

--- a/lib/screens/marketplace_screen.dart
+++ b/lib/screens/marketplace_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class MarketplaceScreen extends StatelessWidget {
+  const MarketplaceScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Marketplace')),
+      body: const Center(
+        child: Text('Marketplace listings will appear here.'),
+      ),
+    );
+  }
+}

--- a/lib/screens/shorts_screen.dart
+++ b/lib/screens/shorts_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class ShortsScreen extends StatelessWidget {
+  const ShortsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Shorts')),
+      body: const Center(
+        child: Text('Short-form videos coming soon.'),
+      ),
+    );
+  }
+}

--- a/test/new_screens_test.dart
+++ b/test/new_screens_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/screens/shorts_screen.dart';
+import 'package:fouta_app/screens/marketplace_screen.dart';
+import 'package:fouta_app/screens/ar_camera_screen.dart';
+
+void main() {
+  testWidgets('Shorts screen shows placeholder', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: ShortsScreen()));
+    expect(find.text('Short-form videos coming soon.'), findsOneWidget);
+  });
+
+  testWidgets('Marketplace screen shows placeholder', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: MarketplaceScreen()));
+    expect(find.text('Marketplace listings will appear here.'), findsOneWidget);
+  });
+
+  testWidgets('AR Camera screen shows placeholder', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: ArCameraScreen()));
+    expect(find.text('AR effects will be available soon.'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add stub screens for Shorts, Marketplace, and AR Camera
- wire new screens into the navigation drawer
- document screens and add placeholder widget tests

## Risks
- placeholders may diverge from final UX; mitigate with future design iterations
- added drawer items could overwhelm users; consider grouping when features mature
- no Flutter toolchain in CI prevented running analysis/tests; ensure tooling before merge
- added screens are unimplemented; may confuse users until fully built out
- minimal tests only cover placeholders; expand coverage with real functionality

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci`
- `npm test --if-present`
- `flutter build web --release` *(fails: command not found)*

## Migration
- none


------
https://chatgpt.com/codex/tasks/task_e_689ba8c0d7ac832b8d6ffca700ec34f4