### PR TITLE
feat: implement app service stubs

### DIFF
--- a/lib/features/analytics/analytics_service.dart
+++ b/lib/features/analytics/analytics_service.dart
@@ -1,4 +1,42 @@
 /// Collects usage metrics and performance traces to guide product decisions.
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+/// Represents a single analytics event.
+class AnalyticsEvent {
+  final String name;
+  final Map<String, Object?> parameters;
+
+  const AnalyticsEvent(this.name, [this.parameters = const {}]);
+
+  @override
+  String toString() => 'AnalyticsEvent(name: $name, parameters: $parameters)';
+}
+
+/// Minimal analytics service that records events in memory and exposes a stream
+/// for interested listeners. In a production environment these events would be
+/// forwarded to an analytics backend and surfaced in dashboards.
 class AnalyticsService {
-  // TODO: send events to analytics backend and surface dashboards.
+  final _events = <AnalyticsEvent>[];
+  final _controller = StreamController<AnalyticsEvent>.broadcast();
+
+  /// Immutable view of recorded events.
+  List<AnalyticsEvent> get events => List.unmodifiable(_events);
+
+  /// Stream of events as they are logged.
+  Stream<AnalyticsEvent> get eventsStream => _controller.stream;
+
+  /// Record an event and notify listeners. Parameters are optional.
+  void logEvent(String name, {Map<String, Object?>? parameters}) {
+    final event = AnalyticsEvent(name, parameters ?? {});
+    _events.add(event);
+    _controller.add(event);
+    debugPrint('Analytics: $event');
+  }
+
+  /// Dispose of resources.
+  void dispose() {
+    _controller.close();
+  }
 }

--- a/lib/features/discovery/discovery_service.dart
+++ b/lib/features/discovery/discovery_service.dart
@@ -1,4 +1,38 @@
 /// Handles content discovery, hashtags, and personalized feed ranking.
 class DiscoveryService {
-  // TODO: implement search, trending topics, and recommendation logic.
+  final List<String> _posts = [];
+  final Map<String, int> _tagCounts = {};
+
+  /// Index a piece of [content] for search and trending hashtag tracking.
+  void indexPost(String content) {
+    _posts.add(content);
+    final regex = RegExp(r'#(\w+)');
+    for (final match in regex.allMatches(content.toLowerCase())) {
+      final tag = match.group(1)!;
+      _tagCounts[tag] = (_tagCounts[tag] ?? 0) + 1;
+    }
+  }
+
+  /// Simple full text search over previously indexed posts.
+  List<String> search(String query) {
+    final q = query.toLowerCase();
+    return _posts.where((p) => p.toLowerCase().contains(q)).toList();
+  }
+
+  /// Returns the most frequently used hashtags in descending order.
+  List<String> trendingTags({int limit = 10}) {
+    final entries = _tagCounts.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    return entries.take(limit).map((e) => '#${e.key}').toList();
+  }
+
+  /// Naive recommendation engine that suggests posts containing the top tag.
+  List<String> recommendedPosts() {
+    final trending = trendingTags(limit: 1);
+    if (trending.isEmpty) return [];
+    final tag = trending.first.substring(1); // remove '#'
+    return _posts
+        .where((p) => p.toLowerCase().contains('#$tag'))
+        .toList();
+  }
 }

--- a/lib/features/growth/growth_service.dart
+++ b/lib/features/growth/growth_service.dart
@@ -1,4 +1,28 @@
 /// Manages onboarding flows, referrals, and social graph import.
+import 'dart:async';
+
+import 'package:uuid/uuid.dart';
+
 class GrowthService {
-  // TODO: implement referral codes and contact syncing.
+  final _referralCodes = <String, String>{}; // code -> userId
+  final Set<String> _syncedContacts = {};
+  final Uuid _uuid = const Uuid();
+
+  /// Generates a unique referral code for [userId].
+  String createReferralCode(String userId) {
+    final code = _uuid.v4();
+    _referralCodes[code] = userId;
+    return code;
+  }
+
+  /// Returns the userId associated with a referral [code], if any.
+  String? redeemReferralCode(String code) => _referralCodes[code];
+
+  /// Syncs [contacts] with the service and returns the ones that are newly
+  /// discovered. The sync is simulated with a short delay.
+  Future<List<String>> syncContacts(List<String> contacts) async {
+    final newContacts = contacts.where((c) => _syncedContacts.add(c)).toList();
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    return newContacts;
+  }
 }

--- a/lib/features/monetization/monetization_service.dart
+++ b/lib/features/monetization/monetization_service.dart
@@ -1,4 +1,19 @@
 /// Placeholder for ads, subscriptions, and marketplace transactions.
+import 'dart:async';
+
+/// A naive monetization service that records purchases locally. Real payment
+/// processing would integrate with platform-specific providers.
 class MonetizationService {
-  // TODO: evaluate revenue models and integrate payment providers.
+  final Set<String> _purchases = {};
+
+  /// Simulates purchasing an item identified by [productId]. Always succeeds
+  /// after a short delay and records the purchase locally.
+  Future<bool> purchase(String productId) async {
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    _purchases.add(productId);
+    return true;
+  }
+
+  /// Whether the given [productId] has been purchased in this session.
+  bool hasPurchased(String productId) => _purchases.contains(productId);
 }

--- a/lib/services/stories_service.dart
+++ b/lib/services/stories_service.dart
@@ -1,17 +1,44 @@
 import 'dart:async';
 
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 import '../models/story.dart';
+
+/// Abstraction for persisting story views.
+abstract class StoryViewsStore {
+  Future<void> saveView(String storyId, StoryItem item);
+}
+
+/// Firestore-backed implementation of [StoryViewsStore].
+class FirestoreStoryViewsStore implements StoryViewsStore {
+  final FirebaseFirestore _firestore;
+  FirestoreStoryViewsStore({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  @override
+  Future<void> saveView(String storyId, StoryItem item) {
+    return _firestore
+        .collection('views')
+        .doc(storyId)
+        .collection('items')
+        .doc(item.media.url)
+        .set({'seenAt': FieldValue.serverTimestamp()});
+  }
+}
 
 /// Handles client side state for stories including tracking seen items.
 class StoriesService {
   final _seenCache = <String>{};
+  final StoryViewsStore _store;
+
+  StoriesService({StoryViewsStore? store})
+      : _store = store ?? FirestoreStoryViewsStore();
 
   bool isItemSeen(StoryItem item) => _seenCache.contains(item.media.url);
 
   Future<void> markItemSeen(String storyId, StoryItem item) async {
     if (isItemSeen(item)) return;
     _seenCache.add(item.media.url);
-    // TODO: Persist to backend e.g. Firestore `views/{userId}` collection.
-    await Future<void>.value();
+    await _store.saveView(storyId, item);
   }
 }

--- a/lib/widgets/chat/chat_composer.dart
+++ b/lib/widgets/chat/chat_composer.dart
@@ -1,6 +1,9 @@
 // lib/widgets/chat/chat_composer.dart
 
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:uuid/uuid.dart';
+
 import '../../models/message.dart';
 import '../../models/media_item.dart';
 
@@ -16,6 +19,7 @@ class ChatComposer extends StatefulWidget {
 class _ChatComposerState extends State<ChatComposer> {
   final TextEditingController _controller = TextEditingController();
   final List<MediaItem> _attachments = [];
+  final ImagePicker _picker = ImagePicker();
 
   void _handleSend() {
     final text = _controller.text.trim();
@@ -27,47 +31,117 @@ class _ChatComposerState extends State<ChatComposer> {
     });
   }
 
+  Future<void> _pickAttachment() async {
+    final picked = await _picker.pickImage(source: ImageSource.gallery);
+    if (picked != null) {
+      setState(() {
+        _attachments.add(
+          MediaItem(
+            id: const Uuid().v4(),
+            type: MediaType.image,
+            url: picked.path,
+          ),
+        );
+      });
+    }
+  }
+
+  Future<void> _pickEmoji() async {
+    const emojis = ['😀', '😂', '😍', '🤔', '👍', '🎉'];
+    final selected = await showModalBottomSheet<String>(
+      context: context,
+      builder: (context) {
+        return GridView.count(
+          crossAxisCount: 6,
+          children: [
+            for (final e in emojis)
+              InkWell(
+                onTap: () => Navigator.pop(context, e),
+                child: Center(
+                  child: Text(
+                    e,
+                    style: const TextStyle(fontSize: 24),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+    if (selected != null) {
+      final text = _controller.text;
+      final selection = _controller.selection;
+      final newText =
+          text.replaceRange(selection.start, selection.end, selected);
+      _controller.text = newText;
+      _controller.selection = TextSelection.collapsed(
+          offset: selection.start + selected.length);
+      setState(() {});
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    final canSend = _controller.text.trim().isNotEmpty || _attachments.isNotEmpty;
+    final canSend =
+        _controller.text.trim().isNotEmpty || _attachments.isNotEmpty;
     return Material(
       color: Theme.of(context).colorScheme.surface,
       child: SafeArea(
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.end,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            IconButton(
-              icon: const Icon(Icons.attach_file),
-              onPressed: () {
-                // TODO: implement attachment picker
-              },
-              tooltip: 'Attach',
-            ),
-            Expanded(
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxHeight: 150),
-                child: TextField(
-                  controller: _controller,
-                  maxLines: null,
-                  decoration: const InputDecoration(
-                    hintText: 'Message',
-                    border: InputBorder.none,
-                  ),
-                  onChanged: (_) => setState(() {}),
+            if (_attachments.isNotEmpty)
+              Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                child: Wrap(
+                  spacing: 8,
+                  children: List.generate(_attachments.length, (index) {
+                    final item = _attachments[index];
+                    return Chip(
+                      label: Text(item.type.name),
+                      onDeleted: () {
+                        setState(() {
+                          _attachments.removeAt(index);
+                        });
+                      },
+                    );
+                  }),
                 ),
               ),
-            ),
-            IconButton(
-              icon: const Icon(Icons.emoji_emotions_outlined),
-              onPressed: () {
-                // TODO: implement emoji picker
-              },
-              tooltip: 'Emoji',
-            ),
-            IconButton(
-              icon: const Icon(Icons.send),
-              onPressed: canSend ? _handleSend : null,
-              tooltip: 'Send',
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.attach_file),
+                  onPressed: _pickAttachment,
+                  tooltip: 'Attach',
+                ),
+                Expanded(
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxHeight: 150),
+                    child: TextField(
+                      controller: _controller,
+                      maxLines: null,
+                      decoration: const InputDecoration(
+                        hintText: 'Message',
+                        border: InputBorder.none,
+                      ),
+                      onChanged: (_) => setState(() {}),
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.emoji_emotions_outlined),
+                  onPressed: _pickEmoji,
+                  tooltip: 'Emoji',
+                ),
+                IconButton(
+                  icon: const Icon(Icons.send),
+                  onPressed: canSend ? _handleSend : null,
+                  tooltip: 'Send',
+                ),
+              ],
             ),
           ],
         ),

--- a/lib/widgets/chat/message_bubble.dart
+++ b/lib/widgets/chat/message_bubble.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import '../../models/message.dart';
+import '../../models/media_item.dart';
 
 class MessageBubble extends StatelessWidget {
   final Message message;
@@ -36,15 +37,130 @@ class MessageBubble extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            if (message.replyToMessageId != null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Text(
+                  'Replying to ${message.replyToMessageId}',
+                  style: TextStyle(
+                    color: textColor.withOpacity(0.7),
+                    fontSize: 12,
+                  ),
+                ),
+              ),
             if (message.text != null)
               Text(
                 message.text!,
                 style: TextStyle(color: textColor),
               ),
-            // TODO: render attachments, replies, reactions, status indicators
+            if (message.attachments.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: message.attachments
+                      .map((a) => Padding(
+                            padding: const EdgeInsets.only(bottom: 8),
+                            child: _AttachmentView(attachment: a),
+                          ))
+                      .toList(),
+                ),
+              ),
+            if (message.reactions.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Wrap(
+                  spacing: 4,
+                  children: message.reactions.entries
+                      .map((e) => Text(
+                            '${e.key} ${e.value.length}',
+                            style:
+                                TextStyle(color: textColor, fontSize: 12),
+                          ))
+                      .toList(),
+                ),
+              ),
+            Align(
+              alignment: Alignment.bottomRight,
+              child: _StatusIndicator(
+                status: message.status,
+                onRetry: onRetry,
+                color: textColor,
+              ),
+            ),
           ],
         ),
       ),
     );
+  }
+}
+
+class _AttachmentView extends StatelessWidget {
+  final MediaItem attachment;
+
+  const _AttachmentView({required this.attachment});
+
+  @override
+  Widget build(BuildContext context) {
+    if (attachment.type == MediaType.image) {
+      return ClipRRect(
+        borderRadius: BorderRadius.circular(8),
+        child: Image.network(
+          attachment.url,
+          height: 150,
+          width: 150,
+          fit: BoxFit.cover,
+        ),
+      );
+    }
+    return Container(
+      height: 150,
+      width: 150,
+      color: Colors.black26,
+      child: const Icon(Icons.play_arrow),
+    );
+  }
+}
+
+class _StatusIndicator extends StatelessWidget {
+  final MessageStatus status;
+  final VoidCallback? onRetry;
+  final Color color;
+
+  const _StatusIndicator(
+      {required this.status, this.onRetry, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    IconData icon;
+    Color? iconColor = color;
+    switch (status) {
+      case MessageStatus.sending:
+        icon = Icons.access_time;
+        iconColor = color.withOpacity(0.7);
+        break;
+      case MessageStatus.sent:
+        icon = Icons.check;
+        iconColor = color.withOpacity(0.7);
+        break;
+      case MessageStatus.delivered:
+        icon = Icons.done_all;
+        iconColor = color.withOpacity(0.7);
+        break;
+      case MessageStatus.read:
+        icon = Icons.done_all;
+        break;
+      case MessageStatus.failed:
+        icon = Icons.error;
+        iconColor = Theme.of(context).colorScheme.error;
+        if (onRetry != null) {
+          return GestureDetector(
+            onTap: onRetry,
+            child: Icon(icon, color: iconColor, size: 16),
+          );
+        }
+        break;
+    }
+    return Icon(icon, color: iconColor, size: 16);
   }
 }

--- a/test/analytics_service_test.dart
+++ b/test/analytics_service_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/features/analytics/analytics_service.dart';
+
+void main() {
+  test('logEvent stores event and emits through stream', () async {
+    final service = AnalyticsService();
+    final events = <AnalyticsEvent>[];
+    service.eventsStream.listen(events.add);
+
+    service.logEvent('login', parameters: {'method': 'email'});
+    await Future<void>.delayed(Duration.zero);
+
+    expect(service.events.single.name, 'login');
+    expect(events.single.parameters['method'], 'email');
+  });
+}

--- a/test/discovery_service_test.dart
+++ b/test/discovery_service_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/features/discovery/discovery_service.dart';
+
+void main() {
+  test('indexPost tracks trending hashtags', () {
+    final service = DiscoveryService();
+    service.indexPost('hello #world');
+    service.indexPost('another #world #foo');
+    final trending = service.trendingTags(limit: 2);
+    expect(trending.first, '#world');
+    expect(trending, contains('#foo'));
+    expect(service.search('another'), ['another #world #foo']);
+  });
+
+  test('recommendedPosts returns posts with top tag', () {
+    final service = DiscoveryService();
+    service.indexPost('one #tag');
+    service.indexPost('two #tag');
+    service.indexPost('three #other');
+    final rec = service.recommendedPosts();
+    expect(rec, containsAll(['one #tag', 'two #tag']));
+  });
+}

--- a/test/growth_service_test.dart
+++ b/test/growth_service_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/features/growth/growth_service.dart';
+
+void main() {
+  test('referral code generation and redemption', () {
+    final service = GrowthService();
+    final code = service.createReferralCode('user1');
+    expect(service.redeemReferralCode(code), 'user1');
+  });
+
+  test('syncContacts returns only new contacts', () async {
+    final service = GrowthService();
+    final first = await service.syncContacts(['a', 'b']);
+    final second = await service.syncContacts(['b', 'c']);
+    expect(first, ['a', 'b']);
+    expect(second, ['c']);
+  });
+}

--- a/test/monetization_service_test.dart
+++ b/test/monetization_service_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/features/monetization/monetization_service.dart';
+
+void main() {
+  test('purchase records product', () async {
+    final service = MonetizationService();
+    final result = await service.purchase('pro');
+    expect(result, true);
+    expect(service.hasPurchased('pro'), true);
+  });
+}

--- a/test/stories_service_test.dart
+++ b/test/stories_service_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/models/media_item.dart';
+import 'package:fouta_app/models/story.dart';
+import 'package:fouta_app/services/stories_service.dart';
+
+class _MemoryViewsStore implements StoryViewsStore {
+  final Map<String, Map<String, Map<String, dynamic>>> data = {};
+
+  @override
+  Future<void> saveView(String storyId, StoryItem item) async {
+    data.putIfAbsent(storyId, () => {});
+    data[storyId]![item.media.url] = {'seenAt': DateTime.now()};
+  }
+}
+
+void main() {
+  test('markItemSeen caches and persists', () async {
+    final store = _MemoryViewsStore();
+    final service = StoriesService(store: store);
+    final item = StoryItem(
+      media: const MediaItem(id: '1', type: MediaType.image, url: 'url1'),
+    );
+
+    await service.markItemSeen('story1', item);
+    expect(service.isItemSeen(item), true);
+    expect(store.data['story1']!.containsKey('url1'), true);
+  });
+}


### PR DESCRIPTION
## Summary
- flesh out analytics, growth, monetization, discovery, and stories services
- wire up chat composer with attachment and emoji pickers
- render message attachments, replies, reactions, and status indicators
- add unit tests covering new service logic

## Risks
- simplified in-memory implementations may not scale; monitor memory usage
- emoji and attachment pickers rely on platform APIs—verify on all targets
- message bubble rendering assumes valid media URLs; add error handling in future
- story view persistence is asynchronous; failed writes currently ignored
- discovery recommendations use naive heuristics; results may be suboptimal

## Tests
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci`
- `npm test --if-present`
- `flutter build web --release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bac19579c832b9231f1c434d0b58f