### PR TITLE
feat(discovery): search screen, hashtag index, trending chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
 
+- 2025-08-13 – Search, hashtag index, trending chips.
 - 2025-08-15 – Added discovery ranking, onboarding, AR camera, shorts module, marketplace, growth, moderation and analytics updates.
 - 2025-08-12 – Hardened feed parsing with safe numeric/list handling and added empty-state guards for Shorts and Marketplace screens.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ Dedicated feature modules keep the project competitive with larger platforms. Th
 - `marketplace_screen.dart`
   - Icons: storefront_outlined
   - Colors: None
+- `search_screen.dart`
+  - Icons: search
+  - Colors: None
 - `shorts_screen.dart`
   - Icons: play_arrow_outlined
   - Colors: None
@@ -289,6 +292,7 @@ flutter test
 
 ## Change Log
 
+- 2025-08-13 00:00 UTC – Search, hashtag index, trending chips.
 - 2025-08-09 01:30 UTC – Implemented server-side media pipeline generating progressive images, video posters, and blurhash placeholders.
 - 2025-08-09 01:39 UTC – Introduced new story models, tray, viewer scaffolding, and documented gestures and accessibility.
 - 2025-08-09 01:39 UTC – Introduced chat composer, message models, and placeholders for advanced chat features.

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -1,0 +1,96 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:fouta_app/utils/firestore_paths.dart';
+
+class SearchScreen extends StatefulWidget {
+  const SearchScreen({super.key});
+
+  @override
+  State<SearchScreen> createState() => _SearchScreenState();
+}
+
+class _SearchScreenState extends State<SearchScreen> {
+  final TextEditingController _controller = TextEditingController();
+  List<QueryDocumentSnapshot<Map<String, dynamic>>> _postResults = [];
+  List<QueryDocumentSnapshot<Map<String, dynamic>>> _userResults = [];
+  bool _loading = false;
+
+  Future<void> _search(String value) async {
+    final query = value.trim().toLowerCase();
+    if (query.isEmpty) {
+      setState(() {
+        _postResults = [];
+        _userResults = [];
+      });
+      return;
+    }
+    setState(() => _loading = true);
+    final firestore = FirebaseFirestore.instance;
+    final posts = await firestore
+        .collection(FirestorePaths.posts())
+        .where('contentLower', isGreaterThanOrEqualTo: query, isLessThanOrEqualTo: '$query\uf8ff')
+        .get();
+    final users = await firestore
+        .collection(FirestorePaths.users())
+        .where('displayNameLower', isGreaterThanOrEqualTo: query, isLessThanOrEqualTo: '$query\uf8ff')
+        .get();
+    if (!mounted) return;
+    setState(() {
+      _postResults = posts.docs;
+      _userResults = users.docs;
+      _loading = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Search')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: TextField(
+              controller: _controller,
+              textInputAction: TextInputAction.search,
+              onSubmitted: _search,
+              decoration: const InputDecoration(
+                hintText: 'Search posts and users',
+                border: OutlineInputBorder(),
+              ),
+            ),
+          ),
+          if (_loading) const LinearProgressIndicator(),
+          Expanded(
+            child: ListView(
+              children: [
+                const ListTile(title: Text('Posts')),
+                if (_postResults.isEmpty)
+                  const ListTile(title: Text('No posts found'))
+                else
+                  ..._postResults.map((d) {
+                    final data = d.data();
+                    return ListTile(title: Text(data['content'] ?? ''));
+                  }),
+                const ListTile(title: Text('Users')),
+                if (_userResults.isEmpty)
+                  const ListTile(title: Text('No users found'))
+                else
+                  ..._userResults.map((d) {
+                    final data = d.data();
+                    return ListTile(title: Text(data['displayName'] ?? ''));
+                  }),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/utils/firestore_paths.dart
+++ b/lib/utils/firestore_paths.dart
@@ -16,6 +16,8 @@ class FirestorePaths {
       'artifacts/$appId/public/data/events';
   static String stories([String appId = APP_ID]) =>
       'artifacts/$appId/public/data/stories';
+  static String hashtags([String appId = APP_ID]) =>
+      'artifacts/$appId/public/data/hashtags';
   static String profileImages([String appId = APP_ID]) =>
       'artifacts/$appId/public/data/profile_images';
 }

--- a/lib/widgets/trending_chip_bar.dart
+++ b/lib/widgets/trending_chip_bar.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class TrendingChipBar extends StatelessWidget {
+  const TrendingChipBar({
+    super.key,
+    required this.tags,
+    required this.onSelected,
+    this.selectedTag,
+  });
+
+  final List<String> tags;
+  final ValueChanged<String> onSelected;
+  final String? selectedTag;
+
+  @override
+  Widget build(BuildContext context) {
+    if (tags.isEmpty) return const SizedBox.shrink();
+    return SizedBox(
+      height: 40,
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        children: tags
+            .map((t) => Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                  child: ChoiceChip(
+                    label: Text('#$t'),
+                    selected: selectedTag == t,
+                    onSelected: (_) => onSelected(t),
+                  ),
+                ))
+            .toList(),
+      ),
+    );
+  }
+}

--- a/test/hashtag_index_test.dart
+++ b/test/hashtag_index_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/features/discovery/discovery_service.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fouta_app/main.dart';
+
+class _FakeFirestore implements FirebaseFirestore {
+  final Map<String, Map<String, dynamic>> data = {};
+
+  @override
+  CollectionReference<Map<String, dynamic>> collection(String path) {
+    return _FakeCollection(data, path);
+  }
+
+  @override
+  Future<T> runTransaction<T>(Future<T> Function(Transaction) handler,
+      {Duration timeout = const Duration(seconds: 5), int maxAttempts = 5}) async {
+    final tx = _FakeTransaction(data);
+    return handler(tx);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeCollection implements CollectionReference<Map<String, dynamic>> {
+  _FakeCollection(this.store, this.path);
+  final Map<String, Map<String, dynamic>> store;
+  final String path;
+  @override
+  DocumentReference<Map<String, dynamic>> doc([String? id]) {
+    return _FakeDoc(store, '$path/${id ?? 'id'}');
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeDoc implements DocumentReference<Map<String, dynamic>> {
+  _FakeDoc(this.store, this.path);
+  final Map<String, Map<String, dynamic>> store;
+  final String path;
+
+  @override
+  Future<DocumentSnapshot<Map<String, dynamic>>> get([GetOptions? options]) async {
+    return _FakeSnapshot(store[path]);
+  }
+
+  @override
+  Future<void> set(Map<String, dynamic> data, [SetOptions? options]) async {
+    if (options?.merge == true && store[path] != null) {
+      store[path] = {...store[path]!, ...data};
+    } else {
+      store[path] = data;
+    }
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeSnapshot implements DocumentSnapshot<Map<String, dynamic>> {
+  _FakeSnapshot(this._data);
+  final Map<String, dynamic>? _data;
+  @override
+  Map<String, dynamic>? data() => _data;
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeTransaction implements Transaction {
+  _FakeTransaction(this.store);
+  final Map<String, Map<String, dynamic>> store;
+
+  @override
+  Future<DocumentSnapshot<Map<String, dynamic>>> get(
+      DocumentReference<Map<String, dynamic>> doc) {
+    return (doc as _FakeDoc).get();
+  }
+
+  @override
+  Transaction set(DocumentReference<Map<String, dynamic>> doc,
+      Map<String, dynamic> data,
+      [SetOptions? options]) {
+    (doc as _FakeDoc).set(data, options);
+    return this;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  test('extractHashtags parses unique tags', () {
+    final tags = DiscoveryService.extractHashtags('Hello #World #flutter #WORLD');
+    expect(tags, containsAll(['world', 'flutter']));
+    expect(tags.length, 2);
+  });
+
+  test('updateHashtagAggregates increments and decrements counts', () async {
+    final fake = _FakeFirestore();
+    await DiscoveryService.updateHashtagAggregates(fake, ['foo', 'bar']);
+    final base = 'artifacts/$APP_ID/public/data/hashtags';
+    expect(fake.data['$base/foo']?['count'], 1);
+    await DiscoveryService.updateHashtagAggregates(fake, ['bar'],
+        oldTags: ['foo', 'bar']);
+    expect(fake.data['$base/foo']?['count'], 0);
+    expect(fake.data['$base/bar']?['count'], 2);
+  });
+}

--- a/test/widgets/trending_chip_bar_test.dart
+++ b/test/widgets/trending_chip_bar_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/widgets/trending_chip_bar.dart';
+
+void main() {
+  testWidgets('TrendingChipBar renders and handles tap', (tester) async {
+    String? tapped;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TrendingChipBar(
+            tags: const ['one', 'two'],
+            selectedTag: null,
+            onSelected: (t) => tapped = t,
+          ),
+        ),
+      ),
+    );
+    expect(find.text('#one'), findsOneWidget);
+    await tester.tap(find.text('#one'));
+    expect(tapped, 'one');
+  });
+}


### PR DESCRIPTION
## Summary
- index post hashtags under `posts/{id}/meta/hashtags` and aggregate counts in `artifacts/$APP_ID/public/data/hashtags`
- add search screen for posts and usernames plus app bar entry point
- surface top hashtag chips above home feed with fallback tags

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: 403 Forbidden)
- `npm test --if-present`
- `flutter build web --release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bec480ba8832bb07738fa179a43fe