### PR TITLE
feat(chat,notifs): typing/read receipts; basic push opt-in + function trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
 
+- 2025-08-13 – Messaging v2 (typing/read receipts/media hardening); Notifications v1 (opt-in + Function trigger).
 - 2025-08-15 – Added discovery ranking, onboarding, AR camera, shorts module, marketplace, growth, moderation and analytics updates.
 - 2025-08-12 – Hardened feed parsing with safe numeric/list handling and added empty-state guards for Shorts and Marketplace screens.

--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ Run the test suite with:
 flutter test
 ```
 
+## Environment Keys
+
+- `FCM_SERVER_KEY` – required by Cloud Functions `onNewInteraction` to send push notifications. If unset, the function logs a TODO and exits without sending.
+
 ## Change Log
 
 - 2025-08-09 01:30 UTC – Implemented server-side media pipeline generating progressive images, video posters, and blurhash placeholders.
@@ -312,6 +316,7 @@ flutter test
 - 2025-08-12 20:39 UTC – Enabled users to report posts for moderation review.
 - 2025-08-12 20:52 UTC – Added Shorts, Marketplace, and AR Camera stub screens accessible from the navigation drawer.
 - 2025-08-15 00:00 UTC – Introduced ranking service, onboarding flow, AR effects, shorts feed, marketplace, growth and moderation tools, and Firebase Analytics integration.
+- 2025-08-13 01:42 UTC – Messaging v2 (typing/read receipts/media hardening); Notifications v1 (opt-in + Function trigger).
 
 ## Contributing
 - Follow the logging and documentation guidelines outlined above.

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "22"
+    "node": "20"
   },
   "main": "index.js",
   "dependencies": {

--- a/lib/constants/media_limits.dart
+++ b/lib/constants/media_limits.dart
@@ -2,3 +2,6 @@
 /// Maximum video file size allowed for uploads.
 const int kMaxVideoBytes = 500 * 1024 * 1024; // 500 MB
 
+/// Maximum image file size allowed for uploads.
+const int kMaxImageBytes = 10 * 1024 * 1024; // 10 MB
+

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -38,6 +38,7 @@ import 'package:fouta_app/widgets/fouta_card.dart';
 import 'package:fouta_app/widgets/skeletons/feed_skeleton.dart';
 import 'package:fouta_app/utils/snackbar.dart';
 import 'package:fouta_app/models/story.dart';
+import 'package:fouta_app/services/push_notification_service.dart';
 import 'package:fouta_app/widgets/system/offline_banner.dart';
 import 'package:fouta_app/widgets/post_composer.dart';
 import 'package:fouta_app/screens/bookmarks_screen.dart';
@@ -522,6 +523,7 @@ class _AppDrawer extends StatelessWidget {
             title: const Text('Logout'),
             onTap: () async {
               Navigator.pop(context);
+              await PushNotificationService.disablePush();
               await FirebaseAuth.instance.signOut();
               showMessage('Logged out successfully.');
             },

--- a/lib/services/chat_utils.dart
+++ b/lib/services/chat_utils.dart
@@ -1,0 +1,12 @@
+import '../models/message.dart';
+
+/// Returns true if any user other than [currentUserId] is typing.
+bool otherUsersTyping(Iterable<String> typingUserIds, String currentUserId) {
+  return typingUserIds.any((id) => id != currentUserId);
+}
+
+/// Derives a [MessageStatus] based on the `readAt` map of a message.
+MessageStatus statusFromReadAt(Map<String, dynamic>? readAt, String currentUserId) {
+  final others = readAt?.keys.where((id) => id != currentUserId) ?? Iterable.empty();
+  return others.isNotEmpty ? MessageStatus.read : MessageStatus.sent;
+}

--- a/test/chat_utils_test.dart
+++ b/test/chat_utils_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/services/chat_utils.dart';
+import 'package:fouta_app/models/message.dart';
+
+void main() {
+  test('typing indicator logic', () {
+    expect(otherUsersTyping(['a'], 'b'), true);
+    expect(otherUsersTyping(['a', 'b'], 'b'), true);
+    expect(otherUsersTyping(['b'], 'b'), false);
+  });
+
+  test('read receipt stamp', () {
+    expect(statusFromReadAt({'a': 1}, 'a'), MessageStatus.sent);
+    expect(statusFromReadAt({'a': 1, 'b': 2}, 'a'), MessageStatus.read);
+  });
+}


### PR DESCRIPTION
## Summary
- add Firestore-based typing indicator docs and read receipt ticks in chat
- gate push notifications behind settings switch and token storage
- Cloud Function sends basic pushes for posts, comments, and DMs when enabled

## Risks
- Cloud Function fan-out loops may increase write costs; monitor usage
- Push opt-in relies on FCM token permissions; user denial may block notifications
- Typing indicators use timers; edge cases may leave stale docs if app crashes
- Media upload progress uses Storage snapshot events; failures could leave spinner
- Offline queue sends messages on reconnect; duplicate sends possible if reconnection logic misfires

## Tests
- `dart format --output=none --set-exit-if-changed .` *(command not found)*
- `flutter format lib test functions` *(command not found)*
- `flutter pub get` *(command not found)*
- `flutter analyze` *(command not found)*
- `flutter test --no-pub --coverage` *(command not found)*
- `npm ci && npm test --if-present` *(403 Forbidden)*
- `flutter build web --release` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689bec3038e4832bbcb07f8a05a677a0