### PR TITLE
ci: add flutter and functions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches: [dev, feature/**, fix/**]
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  flutter:
+    name: Flutter analyze, tests, and web build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Flutter (stable)
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Flutter version
+        run: flutter --version
+
+      - name: Pub get
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Format check
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Tests (with coverage)
+        run: flutter test --no-pub --coverage
+
+      - name: Build web (release smoke test)
+        run: flutter build web --release
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info
+          if-no-files-found: ignore
+
+  functions:
+    name: Cloud Functions tests (Node 20)
+    if: ${{ hashFiles('functions/package.json') != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: functions/package-lock.json
+
+      - name: Install
+        run: npm ci
+        working-directory: functions
+
+      - name: Test
+        run: npm test --if-present
+        working-directory: functions


### PR DESCRIPTION
## Summary
- add CI workflow running Flutter analysis, tests, web build, and Cloud Functions tests

## Risks
- CI runs may be slower due to additional steps; monitor build times
- Node 20 requirement for functions job could fail if mismatched locally; ensure local environments match
- Flutter web build may require extra dependencies in runner

## Tests
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `flutter build web --release` *(fails: command not found)*
- `npm ci` *(fails: package.json and lock file out of sync)*
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_689bf1a8331c832b9c4388e11dc45b5f