### PR TITLE
ci: add GitHub Actions for analyze, tests, and web build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - dev
+      - 'feature/**'
+      - 'fix/**'
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  flutter:
+    name: Flutter analyze, tests, and web build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Flutter analyze
+        run: flutter analyze
+
+      - name: Dart format
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Flutter tests with coverage
+        run: flutter test --no-pub --coverage
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/lcov.info
+
+      - name: Flutter build web (release)
+        run: flutter build web --release
+
+  functions:
+    name: Cloud Functions tests (Node 20)
+    if: ${{ hashFiles('functions/package.json') != '' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: functions
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test --if-present

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - 2025-08-15 – Added discovery ranking, onboarding, AR camera, shorts module, marketplace, growth, moderation and analytics updates.
 - 2025-08-12 – Shorts/Marketplace MVP; safe empty-states; type-safe Firestore parsing.
 - 2025-08-12 – Hardened feed parsing with safe numeric/list handling and added empty-state guards for Shorts and Marketplace screens.
+- 2025-08-12 – Add GitHub Actions CI: analyze, format check, tests with coverage, and web release build.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Media Pipeline](#media-pipeline)
 - [Stories](#stories)
 - [Testing](#testing)
+- [CI & Status Checks](#ci--status-checks)
 - [Change Log](#change-log)
 - [Contributing](#contributing)
 
@@ -289,6 +290,14 @@ Run the test suite with:
 ```bash
 flutter test
 ```
+
+## CI & Status Checks
+
+CI runs on pushes to `dev`, `feature/*`, and `fix/*` branches and on pull requests targeting `dev`.
+It runs `flutter analyze`, `dart format --output=none --set-exit-if-changed .`, `flutter test --no-pub --coverage`, and `flutter build web --release`.
+The coverage report is uploaded as `coverage/lcov.info`.
+To re-run checks, go to Actions and select **Run workflow**.
+
 
 ## Environment Keys
 


### PR DESCRIPTION
## What changed
- add CI workflow running analyze, format check, tests with coverage, and web release build
- document CI workflow in README and CHANGELOG

## Why
- ensure code quality and reliable web builds on pushes and PRs to `dev`

## How to verify
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: package.json and lock file out of sync)*
- `npm test --if-present`
- `flutter build web --release` *(fails: command not found)*

### Enable branch protection
1. Settings → Branches → Add rule for `dev`
2. Require status checks to pass: select “Flutter analyze, tests, and web build” and “Cloud Functions tests (Node 20)” (if present)


------
https://chatgpt.com/codex/tasks/task_e_689bf1de1ee4832b8e0e243060c8c883