### PR TITLE
feat(marketplace,monetization,analytics): filters/favorites; payment intents stubs; admin dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- 2025-08-12 – Marketplace v2 (filters/favorites/seller profile), Monetization stubs (tips/subscriptions/purchase intents), Admin analytics dashboard with daily rollups.
+
 
 - 2025-08-13 – Messaging v2 (typing/read receipts/media hardening); Notifications v1 (opt-in + Function trigger).
 - 2025-08-13 – Search, hashtag index, trending chips.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 - [Development Notes](#development-notes)
 - [Media Pipeline](#media-pipeline)
 - [Stories](#stories)
+- [Monetization](#monetization)
+- [Admin Analytics](#admin-analytics)
 - [Testing](#testing)
 - [Change Log](#change-log)
 - [Contributing](#contributing)
@@ -343,9 +345,33 @@ flutter test
   - `likeIds` (`List<String>`)
   - `createdAt` (`Timestamp`)
 - `artifacts/$APP_ID/public/data/products`
-  - `authorId` (`String`)
+  - `sellerId` (`String`)
   - `urls` (`List<String>`)
   - `title` (`String`)
+  - `category` (`String`)
   - `price` (`double`)
-  - `favoriteIds` (`List<String>`)
+  - `currency` (`String`)
+  - `favoriteUserIds` (`List<String>`)
   - `createdAt` (`Timestamp`)
+
+## Monetization
+Payment flows are stubbed. The app records intents at `artifacts/$APP_ID/public/data/monetization/intents/{intentId}` with:
+- `type` (`tip`\|`subscription`\|`purchase`)
+- `amount` (`double`)
+- `currency` (`String`)
+- `targetUserId` or `productId` (`String`)
+- `createdBy` (`String`)
+- `createdAt` (`Timestamp`)
+- `status` (`draft`\|`ready`\|`completed`\|`failed`)
+
+**Safety:** No payment provider is wired yet; intents are placeholders pending security review.
+
+## Admin Analytics
+Daily rollups stored at `artifacts/$APP_ID/public/data/metrics/daily/{YYYY-MM-DD}` with:
+- `dau` (`int`)
+- `posts` (`int`)
+- `shortViews` (`int`)
+- `purchaseIntents` (`int`)
+
+**Safety:** Aggregations run in scheduled functions; ensure admin-only access and monitor Firestore read costs.
+

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1,0 +1,1 @@
+export {rollupDailyMetrics} from './src/rollupDailyMetrics';

--- a/functions/src/rollupDailyMetrics.ts
+++ b/functions/src/rollupDailyMetrics.ts
@@ -1,0 +1,42 @@
+import {onSchedule} from 'firebase-functions/v2/scheduler';
+import * as admin from 'firebase-admin';
+
+const APP_ID = 'fouta-app';
+const db = admin.firestore();
+
+// Aggregates daily metrics for the previous UTC day.
+// TODO: paginate queries for large datasets to avoid exceeding quotas.
+export const rollupDailyMetrics = onSchedule('0 0 * * *', async () => {
+  const now = new Date();
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const key = start.toISOString().slice(0, 10);
+
+  async function count(path: string) {
+    const snap = await db
+        .collection(path)
+        .where('createdAt', '>=', start)
+        .where('createdAt', '<', end)
+        .get();
+    return snap.size;
+  }
+
+  const dau = await count(`artifacts/${APP_ID}/public/data/users`);
+  const posts = await count(`artifacts/${APP_ID}/public/data/posts`);
+  const shortViews = await count(`artifacts/${APP_ID}/public/data/shorts`);
+  const purchaseIntents = await count(`artifacts/${APP_ID}/public/data/monetization/intents`);
+
+  await db
+      .collection(`artifacts/${APP_ID}/public/data/metrics/daily`)
+      .doc(key)
+      .set(
+        {
+          dau,
+          posts,
+          shortViews,
+          purchaseIntents,
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        },
+        {merge: true},
+      );
+});

--- a/lib/features/marketplace/marketplace_service.dart
+++ b/lib/features/marketplace/marketplace_service.dart
@@ -6,45 +6,53 @@ import '../../utils/json_safety.dart';
 class Product {
   Product({
     required this.id,
-    required this.authorId,
+    required this.sellerId,
     required this.urls,
     required this.title,
+    required this.category,
     required this.price,
+    required this.currency,
     this.description,
-    required this.favoriteIds,
+    required this.favoriteUserIds,
     this.createdAt,
   });
 
   final String id;
-  final String authorId;
+  final String sellerId;
   final List<String> urls;
   final String title;
+  final String category;
   final double price;
+  final String currency;
   final String? description;
-  final List<String> favoriteIds;
+  final List<String> favoriteUserIds;
   final DateTime? createdAt;
 
   factory Product.fromDoc(DocumentSnapshot<Map<String, dynamic>> doc) {
     final data = doc.data() ?? {};
     return Product(
       id: doc.id,
-      authorId: data['authorId']?.toString() ?? '',
+      sellerId: data['sellerId']?.toString() ?? '',
       urls: asStringList(data['urls']),
       title: data['title']?.toString() ?? '',
+      category: data['category']?.toString() ?? '',
       price: asDoubleOrNull(data['price']) ?? 0.0,
+      currency: data['currency']?.toString() ?? 'USD',
       description: data['description']?.toString(),
-      favoriteIds: asStringList(data['favoriteIds']),
+      favoriteUserIds: asStringList(data['favoriteUserIds']),
       createdAt: (data['createdAt'] as Timestamp?)?.toDate(),
     );
   }
 
   Map<String, dynamic> toMap() => {
-        'authorId': authorId,
+        'sellerId': sellerId,
         'urls': urls,
         'title': title,
+        'category': category,
         'price': price,
+        'currency': currency,
         if (description != null) 'description': description,
-        'favoriteIds': favoriteIds,
+        'favoriteUserIds': favoriteUserIds,
         'createdAt': FieldValue.serverTimestamp(),
       };
 }
@@ -62,11 +70,29 @@ class MarketplaceService {
       .doc('data')
       .collection('products');
 
-  Stream<List<Product>> streamProducts() {
-    return _collection
-        .orderBy('createdAt', descending: true)
-        .snapshots()
-        .map((s) => s.docs.map(Product.fromDoc).toList());
+  Stream<List<Product>> streamProducts({
+    String? category,
+    double? minPrice,
+    double? maxPrice,
+    String? query,
+  }) {
+    Query<Map<String, dynamic>> ref =
+        _collection.orderBy('createdAt', descending: true);
+    if (category != null && category.isNotEmpty) {
+      ref = ref.where('category', isEqualTo: category);
+    }
+    if (minPrice != null) {
+      ref = ref.where('price', isGreaterThanOrEqualTo: minPrice);
+    }
+    if (maxPrice != null) {
+      ref = ref.where('price', isLessThanOrEqualTo: maxPrice);
+    }
+    if (query != null && query.isNotEmpty) {
+      ref = ref
+          .where('title', isGreaterThanOrEqualTo: query)
+          .where('title', isLessThan: '$query\uf8ff');
+    }
+    return ref.snapshots().map((s) => s.docs.map(Product.fromDoc).toList());
   }
 
   Future<void> createProduct(Product product) => _collection.add(product.toMap());
@@ -74,10 +100,10 @@ class MarketplaceService {
   Future<void> toggleFavorite(String productId, String userId) async {
     final doc = _collection.doc(productId);
     final snap = await doc.get();
-    final favs = asStringList(snap.data()?['favoriteIds']);
+    final favs = asStringList(snap.data()?['favoriteUserIds']);
     final value = favs.contains(userId)
         ? FieldValue.arrayRemove([userId])
         : FieldValue.arrayUnion([userId]);
-    await doc.update({'favoriteIds': value});
+    await doc.update({'favoriteUserIds': value});
   }
 }

--- a/lib/features/marketplace/product_card.dart
+++ b/lib/features/marketplace/product_card.dart
@@ -3,10 +3,20 @@ import 'package:flutter/material.dart';
 import 'marketplace_service.dart';
 
 class ProductCard extends StatelessWidget {
-  const ProductCard({super.key, required this.product, this.onTap});
+  const ProductCard({
+    super.key,
+    required this.product,
+    this.onTap,
+    this.onFavorite,
+    this.isFavorited = false,
+    this.onSellerTap,
+  });
 
   final Product product;
   final VoidCallback? onTap;
+  final VoidCallback? onFavorite;
+  final bool isFavorited;
+  final VoidCallback? onSellerTap;
 
   @override
   Widget build(BuildContext context) {
@@ -19,12 +29,29 @@ class ProductCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Expanded(
-              child: image != null
-                  ? Image.network(image, width: double.infinity, fit: BoxFit.cover)
-                  : Container(
-                      color: Colors.grey.shade300,
-                      child: const Icon(Icons.image, size: 48),
+              child: Stack(
+                children: [
+                  Positioned.fill(
+                    child: image != null
+                        ? Image.network(image, width: double.infinity, fit: BoxFit.cover)
+                        : Container(
+                            color: Colors.grey.shade300,
+                            child: const Icon(Icons.image, size: 48),
+                          ),
+                  ),
+                  Positioned(
+                    top: 4,
+                    right: 4,
+                    child: IconButton(
+                      icon: Icon(
+                        isFavorited ? Icons.favorite : Icons.favorite_border,
+                        color: isFavorited ? Colors.red : Colors.white,
+                      ),
+                      onPressed: onFavorite,
                     ),
+                  ),
+                ],
+              ),
             ),
             Padding(
               padding: const EdgeInsets.all(8),
@@ -36,13 +63,16 @@ class ProductCard extends StatelessWidget {
             ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: Text('\$${product.price.toStringAsFixed(2)}'),
+              child: Text('${product.currency}${product.price.toStringAsFixed(2)}'),
             ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              child: Text(
-                product.authorId,
-                style: Theme.of(context).textTheme.bodySmall,
+              child: GestureDetector(
+                onTap: onSellerTap,
+                child: Text(
+                  product.sellerId,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
               ),
             ),
           ],

--- a/lib/screens/admin/admin_analytics_dashboard_screen.dart
+++ b/lib/screens/admin/admin_analytics_dashboard_screen.dart
@@ -1,0 +1,73 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+import '../../main.dart';
+
+class AdminAnalyticsDashboardScreen extends StatelessWidget {
+  const AdminAnalyticsDashboardScreen({super.key});
+
+  bool _isAdmin(User? user) {
+    const admins = {'test-admin-uid'}; // Replace with custom claims check.
+    return user != null && admins.contains(user.uid);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = FirebaseAuth.instance.currentUser;
+    if (!_isAdmin(user)) {
+      return const Scaffold(body: Center(child: Text('Not authorized')));
+    }
+    final date = DateTime.now().toUtc();
+    final key = '${date.year.toString().padLeft(4, '0')}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+    final doc = FirebaseFirestore.instance
+        .collection('artifacts')
+        .doc(APP_ID)
+        .collection('public')
+        .doc('data')
+        .collection('metrics')
+        .collection('daily')
+        .doc(key);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Admin Analytics')),
+      body: FutureBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+        future: doc.get(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final data = snapshot.data!.data() ?? {};
+          final dau = data['dau'] ?? 0;
+          final posts = data['posts'] ?? 0;
+          final shorts = data['shortViews'] ?? 0;
+          final intents = data['purchaseIntents'] ?? 0;
+          final missing = snapshot.data!.exists ? '' : 'No metrics for today';
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              _metricCard('DAU', dau),
+              _metricCard('Posts created', posts),
+              _metricCard('Shorts views', shorts),
+              _metricCard('Marketplace intents', intents),
+              if (missing.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(missing),
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _metricCard(String title, int value) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      child: ListTile(
+        title: Text(title),
+        trailing: Text(value.toString()),
+      ),
+    );
+  }
+}

--- a/lib/screens/marketplace_filters_sheet.dart
+++ b/lib/screens/marketplace_filters_sheet.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+class MarketplaceFilters {
+  MarketplaceFilters({this.category, this.minPrice, this.maxPrice, this.query});
+
+  String? category;
+  double? minPrice;
+  double? maxPrice;
+  String? query;
+}
+
+class MarketplaceFiltersSheet extends StatefulWidget {
+  const MarketplaceFiltersSheet({
+    super.key,
+    required this.initial,
+    required this.onApply,
+  });
+
+  final MarketplaceFilters initial;
+  final void Function(MarketplaceFilters) onApply;
+
+  @override
+  State<MarketplaceFiltersSheet> createState() => _MarketplaceFiltersSheetState();
+}
+
+class _MarketplaceFiltersSheetState extends State<MarketplaceFiltersSheet> {
+  late final TextEditingController _category;
+  late final TextEditingController _min;
+  late final TextEditingController _max;
+  late final TextEditingController _query;
+
+  @override
+  void initState() {
+    super.initState();
+    _category = TextEditingController(text: widget.initial.category);
+    _min = TextEditingController(
+        text: widget.initial.minPrice?.toStringAsFixed(2) ?? '');
+    _max = TextEditingController(
+        text: widget.initial.maxPrice?.toStringAsFixed(2) ?? '');
+    _query = TextEditingController(text: widget.initial.query);
+  }
+
+  @override
+  void dispose() {
+    _category.dispose();
+    _min.dispose();
+    _max.dispose();
+    _query.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: _query,
+            decoration: const InputDecoration(labelText: 'Search'),
+          ),
+          TextField(
+            controller: _category,
+            decoration: const InputDecoration(labelText: 'Category'),
+          ),
+          TextField(
+            controller: _min,
+            decoration: const InputDecoration(labelText: 'Min price'),
+            keyboardType: TextInputType.number,
+          ),
+          TextField(
+            controller: _max,
+            decoration: const InputDecoration(labelText: 'Max price'),
+            keyboardType: TextInputType.number,
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () {
+              final filters = MarketplaceFilters(
+                category: _category.text.isEmpty ? null : _category.text,
+                minPrice: double.tryParse(_min.text),
+                maxPrice: double.tryParse(_max.text),
+                query: _query.text.isEmpty ? null : _query.text,
+              );
+              widget.onApply(filters);
+              Navigator.pop(context);
+            },
+            child: const Text('Apply'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/seller_profile_screen.dart
+++ b/lib/screens/seller_profile_screen.dart
@@ -1,0 +1,90 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+import '../features/marketplace/marketplace_service.dart';
+import '../features/marketplace/product_card.dart';
+import '../features/monetization/monetization_service.dart';
+import 'chat_screen.dart';
+
+class SellerProfileScreen extends StatelessWidget {
+  SellerProfileScreen({super.key, required this.sellerId, MarketplaceService? service})
+      : _service = service ?? MarketplaceService();
+
+  final String sellerId;
+  final MarketplaceService _service;
+
+  @override
+  Widget build(BuildContext context) {
+    final monetization = MonetizationService();
+    final user = FirebaseAuth.instance.currentUser;
+    return Scaffold(
+      appBar: AppBar(title: Text('Seller $sellerId')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => ChatScreen(otherUserId: sellerId),
+                      ),
+                    );
+                  },
+                  child: const Text('Message seller'),
+                ),
+                const SizedBox(width: 8),
+                ElevatedButton(
+                  onPressed: () async {
+                    final id = await monetization.createTipIntent(
+                      amount: 0,
+                      currency: 'USD',
+                      targetUserId: sellerId,
+                      createdBy: user?.uid ?? 'anon',
+                    );
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text('Support intent: $id')),
+                      );
+                    }
+                    // TODO: connect to payment provider once approved.
+                  },
+                  child: const Text('Support Creator'),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: StreamBuilder<List<Product>>(
+              stream: _service.streamProducts(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                final products =
+                    (snapshot.data ?? []).where((p) => p.sellerId == sellerId).toList();
+                if (products.isEmpty) {
+                  return const Center(child: Text('No products'));
+                }
+                return GridView.builder(
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    childAspectRatio: 3 / 4,
+                  ),
+                  itemCount: products.length,
+                  itemBuilder: (context, index) {
+                    final product = products[index];
+                    return ProductCard(product: product);
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dev_dependencies:
     sdk: flutter
   flutter_launcher_icons: ^0.13.1
   flutter_lints: ^3.0.0
+  fake_cloud_firestore: ^2.5.0
 
 dependency_overrides:
 

--- a/test/marketplace_filters_sheet_test.dart
+++ b/test/marketplace_filters_sheet_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fouta_app/screens/marketplace_filters_sheet.dart';
+
+void main() {
+  testWidgets('applies filters', (tester) async {
+    MarketplaceFilters? result;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MarketplaceFiltersSheet(
+          initial: MarketplaceFilters(),
+          onApply: (f) => result = f,
+        ),
+      ),
+    );
+    await tester.enterText(find.byType(TextField).at(0), 'shoes');
+    await tester.enterText(find.byType(TextField).at(1), 'fashion');
+    await tester.enterText(find.byType(TextField).at(2), '10');
+    await tester.enterText(find.byType(TextField).at(3), '100');
+    await tester.tap(find.text('Apply'));
+    await tester.pumpAndSettle();
+    expect(result?.query, 'shoes');
+    expect(result?.category, 'fashion');
+    expect(result?.minPrice, 10);
+    expect(result?.maxPrice, 100);
+  });
+}

--- a/test/monetization_service_test.dart
+++ b/test/monetization_service_test.dart
@@ -1,21 +1,32 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 import 'package:fouta_app/features/monetization/monetization_service.dart';
+import 'package:fouta_app/main.dart';
 
 void main() {
-  test('purchase records product', () async {
-    final service = MonetizationService();
-    final result = await service.purchase('pro');
-    expect(result, true);
-    expect(service.hasPurchased('pro'), true);
-  });
-
-  test('additional monetization methods record purchases', () async {
-    final service = MonetizationService();
-    await service.purchaseProduct('item1');
-    await service.subscribeToCreator('creator');
-    await service.tipCreator('creator', 100);
-    expect(service.hasPurchased('item1'), true);
-    expect(service.hasPurchased('sub-creator'), true);
-    expect(service.hasPurchased('tip-creator-100'), true);
+  test('intent create and status update', () async {
+    final firestore = FakeFirebaseFirestore();
+    final service = MonetizationService(firestore: firestore);
+    final id = await service.createTipIntent(
+      amount: 5,
+      currency: 'USD',
+      targetUserId: 'seller1',
+      createdBy: 'user1',
+    );
+    final doc = await firestore
+        .collection('artifacts')
+        .doc(APP_ID)
+        .collection('public')
+        .doc('data')
+        .collection('monetization')
+        .doc('intents')
+        .collection('items')
+        .doc(id)
+        .get();
+    expect(doc.data()?['type'], 'tip');
+    await service.markIntentStatus(id, 'completed');
+    final updated = await doc.reference.get();
+    expect(updated.data()?['status'], 'completed');
   });
 }


### PR DESCRIPTION
## Summary
- extend marketplace products with category, pricing, seller, and favorites and add filterable streams
- record tip/subscription/purchase intents in Firestore and surface purchase hooks
- add admin analytics dashboard and daily rollup Cloud Function

## Risks
- Firestore rollups and filtered queries may increase read costs; paginate and monitor usage
- Monetization intents lack real payment enforcement; restrict write rules until provider review
- Admin gating uses hardcoded UID which could leak metrics if misconfigured; replace with claims

## Testing
- `flutter pub get` *(fail: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fail: command not found)*
- `flutter analyze` *(fail: command not found)*
- `flutter test --no-pub --coverage` *(fail: command not found)*
- `npm ci` *(fail: 403 Forbidden)*
- `npm test --if-present`
- `flutter build web --release` *(fail: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bf3d5f9d8832bb9a15fed5810f9e1