### PR TITLE
docs(policy): allow branches and new dependencies with DEP records

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Contributor Guide
 
 ## Project
-- Default base branch: `dev`. Never push directly to `main`.
+- Default base branch: `dev`. Do not push directly to `main` (protected).
 - Languages: Flutter (web-first) + Firebase Functions (Node 20).
 
 ## Local checks to run before any PR
@@ -9,19 +9,28 @@
 - `flutter analyze`
 - `dart format --output=none --set-exit-if-changed .`
 - `flutter test --no-pub --coverage`
-- if `/functions` exists: `npm ci` && `npm test --if-present`
-- `flutter build web --release`  # smoke-test
+- If `/functions` exists: `npm ci && npm test --if-present`
+- Optional smoke tests (if environment allows):
+  - `flutter build web --release`
+  - `flutter build apk --debug` (Android)
+  - `flutter build ios --no-codesign` (macOS runner)
 
 ## PR requirements
 - Title uses Conventional Commits.
-- Summary: what/why/how.
+- Summary: what / why / how.
 - Risks: top 5 with mitigations.
-- Tests: list added/updated tests and show the relevant passing output.
+- Tests: list added/updated tests and show relevant passing output.
 - Migration notes (if any).
-- Citations to changed files and test output using Codex’s file/terminal citation format.
+- Citations to changed files and test output (reference paths and commands).
 
-## Repo guardrails
-- Return complete file replacements (no ellipses).
-- Don’t change the custom feed sorting logic.
-- Don’t add new runtime dependencies without noting rationale and security review.
-- No bottom nav on Login/Signup screens.
+## Repo policy (updated)
+- **File output**: Return complete file replacements (no ellipses).
+- **Branches**: Agents **may create/switch** branches (feature/*, fix/*, meta/*). If your system forbids it, work on `dev` and note the fallback in the changelog.
+- **Dependencies**: Agents **may add runtime or dev dependencies** when all of the following are done:
+  1) Create a short DEP record under `docs/dependencies/` using the template (see `DEP-TEMPLATE.md`).
+  2) Update `pubspec.yaml` (and `functions/package.json` if applicable), then run `flutter pub get` (or `npm ci`).
+  3) Update platform settings if required (Android minSdk/Gradle, iOS Pod settings, Web `index.html`).
+  4) Update `README.md` with setup notes if manual steps are needed.
+  5) Ensure tests and CI pass.
+- **Feed sorting**: Do not modify the custom feed sorting unless a task explicitly authorizes it.
+- **Auth screens**: No bottom navigation on Login/Signup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 - 2025-08-12 – Shorts/Marketplace MVP; safe empty-states; type-safe Firestore parsing.
 - 2025-08-12 – Hardened feed parsing with safe numeric/list handling and added empty-state guards for Shorts and Marketplace screens.
 - 2025-08-12 – Add GitHub Actions CI: analyze, format check, tests with coverage, and web release build.
+- 2025-08-12 – Project policy update: allow branch creation/switching and new dependencies with DEP records. If branch switching was forbidden by runtime, changes were committed directly to `dev` (fallback).

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,0 +1,16 @@
+# Dependency Policy
+
+We allow adding new runtime and dev dependencies if they are justified and tested.
+
+## Checklist for each new dependency
+1. Create a DEP record: copy `docs/dependencies/DEP-TEMPLATE.md` to `docs/dependencies/DEP-YYYYMMDD-<name>.md` and fill it.
+2. Update manifests:
+   - Flutter: `pubspec.yaml` then `flutter pub get`
+   - Functions (if used): `functions/package.json` then `npm ci`
+3. Platform notes (if needed):
+   - Android: Gradle/`minSdkVersion`, permissions, ProGuard/r8 rules
+   - iOS: Pod install, entitlements, Info.plist keys
+   - Web: `index.html` tags, service worker updates
+4. Docs: Add any setup notes to `README.md`.
+5. CI: Confirm `flutter analyze`, `dart format --set-exit-if-changed`, and tests pass.
+6. Security: Prefer well‑maintained packages with permissive licenses. Avoid binary blobs.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Getting Started](#getting-started)
 - [Documentation & Logging Guidelines](#documentation--logging-guidelines)
   - [AI Collaboration](#ai-collaboration)
+- [AI Collaboration & Policy](#ai-collaboration--policy)
 - [Development Notes](#development-notes)
 - [Media Pipeline](#media-pipeline)
 - [Stories](#stories)
@@ -218,6 +219,11 @@ For help getting started with Flutter development, view the [online documentatio
 ### AI Collaboration
 - AI agents must document their work, including context, decisions, and timestamps.
 - Append updates to existing documentation and logs rather than overwriting previous entries.
+
+## AI Collaboration & Policy
+- Agents may create or switch branches other than the protected `main` branch.
+- Agents may add runtime and dev dependencies when a DEP record is created and all CI checks pass.
+- See [AGENTS.md](AGENTS.md) and [DEPENDENCIES.md](DEPENDENCIES.md) for full details.
 
 ## Development Notes
 

--- a/docs/dependencies/DEP-TEMPLATE.md
+++ b/docs/dependencies/DEP-TEMPLATE.md
@@ -1,0 +1,30 @@
+# DEP: <package-name>
+Date: YYYY-MM-DD
+Author: <your name or agent>
+Status: Proposed | Adopted
+
+## Purpose
+What problem does this package solve?
+
+## Package
+- Name: <pub.dev/package or npm package>
+- Link: <URL>
+- License: <MIT/Apache-2.0/BSD-3-Clause/...>
+
+## Alternatives considered
+- <option 1> — pros/cons
+- <option 2> — pros/cons
+
+## Platform impact
+- Android: <minSdk/manifest/gradle changes?>  
+- iOS: <pod/entitlements/Info.plist?>  
+- Web: <index.html/service worker?>
+
+## Data, privacy & security
+Any sensitive permissions? Data sent off-device? Mitigation.
+
+## Test & rollout plan
+How to verify locally/CI; partial rollout steps.
+
+## Removal plan
+How to revert if needed.


### PR DESCRIPTION
## Summary
- allow agents to create/switch branches and add runtime or dev dependencies with DEP records
- document dependency workflow and add template for new packages
- note policy update in README and changelog

## Risks
- **Policy misinterpretation**: devs might skip DEP record — *mitigate with template and checklist*
- **Unchecked dependencies**: new deps could bypass review — *mitigate via required CI checks*
- **Branch misuse**: commits may target `main` — *mitigate with explicit warning in docs*
- **Incomplete local setup**: contributors may miss README notes — *mitigate by linking docs*
- **CI failures**: environment limitations may block checks — *mitigate via fallback guidance*

## Tests
- `flutter pub get` *(command not found)*
- `flutter analyze` *(command not found)*
- `dart format --output=none --set-exit-if-changed .` *(command not found)*
- `flutter test --no-pub --coverage` *(command not found)*
- `npm ci` *(lock file out of sync)*
- `npm test --if-present`
- `flutter build web --release` *(command not found)*

## Links
- `AGENTS.md`
- `DEPENDENCIES.md`
- `docs/dependencies/DEP-TEMPLATE.md`


------
https://chatgpt.com/codex/tasks/task_e_689bfe5ad3e8832bb395684f0caf8242