### PR TITLE
feat(i18n): add EN/FR scaffolding and dev sandbox (no app wiring)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- 2025-08-12 – i18n scaffolding (EN/FR) with dev sandbox; no app wiring yet.
 - 2025-08-12 – Notifications v2: per-type prefs, in-app inbox, batched push.
 
 - 2025-08-12 – Reposts/Quote posts; Saved Collections; Share to Story.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [Monetization](#monetization)
 - [Admin Analytics](#admin-analytics)
 - [Notifications](#notifications)
+- [Internationalization (i18n) scaffolding](#internationalization-i18n-scaffolding)
 - [Testing](#testing)
 - [CI & Status Checks](#ci--status-checks)
 - [Change Log](#change-log)
@@ -342,6 +343,16 @@ Firestore: `artifacts/$APP_ID/public/data/events/{eventId}` with fields:
 
 - `products` – documents contain `name`, `price`, `description`, and `imageUrl` for marketplace listings.
 - `purchases` – records `userId`, `productId`, and `timestamp` for digital goods transactions.
+
+## Internationalization (i18n) scaffolding
+
+A basic localization layer exists for English and French. To preview available strings, run the dev sandbox:
+
+```bash
+flutter run lib/devtools/localization_sandbox.dart
+```
+
+Use the buttons to switch languages.
 
 ## Testing
 Run the test suite with:

--- a/lib/devtools/localization_sandbox.dart
+++ b/lib/devtools/localization_sandbox.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import '../l10n/l10n.dart';
+
+void main() => runApp(const LocalizationSandbox());
+
+class LocalizationSandbox extends StatefulWidget {
+  const LocalizationSandbox({super.key});
+
+  @override
+  State<LocalizationSandbox> createState() => _LocalizationSandboxState();
+}
+
+class _LocalizationSandboxState extends State<LocalizationSandbox> {
+  Locale _locale = const Locale('en');
+
+  void _updateLocale(Locale locale) {
+    setState(() => _locale = locale);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      locale: _locale,
+      supportedLocales: AppLocalizations.supportedLocales,
+      localizationsDelegates: const [AppLocalizations.delegate],
+      home: Builder(
+        builder: (context) => Scaffold(
+          appBar: AppBar(
+            title: Text(AppLocalizations.of(context).appName),
+          ),
+          body: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(AppLocalizations.of(context).settings),
+                Text(AppLocalizations.of(context).privacy),
+                Text(AppLocalizations.of(context).save),
+                Text(AppLocalizations.of(context).cancel),
+                Text(AppLocalizations.of(context).post),
+                Text(AppLocalizations.of(context).comment),
+                Text(AppLocalizations.of(context).like),
+                Text(AppLocalizations.of(context).share),
+                Text(AppLocalizations.of(context).follow),
+                Text(AppLocalizations.of(context).followers),
+                const SizedBox(height: 16),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    ElevatedButton(
+                      onPressed: () => _updateLocale(const Locale('en')),
+                      child: const Text('EN'),
+                    ),
+                    const SizedBox(width: 8),
+                    ElevatedButton(
+                      onPressed: () => _updateLocale(const Locale('fr')),
+                      child: const Text('FR'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+const sandboxRouteMap = {
+  '/_dev/l10n': (_) => const LocalizationSandbox(),
+};

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,13 @@
+{
+  "appName": "Fouta",
+  "settings": "Settings",
+  "privacy": "Privacy",
+  "save": "Save",
+  "cancel": "Cancel",
+  "post": "Post",
+  "comment": "Comment",
+  "like": "Like",
+  "share": "Share",
+  "follow": "Follow",
+  "followers": "Followers"
+}

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1,0 +1,13 @@
+{
+  "appName": "Fouta",
+  "settings": "Paramètres",
+  "privacy": "Confidentialité",
+  "save": "Enregistrer",
+  "cancel": "Annuler",
+  "post": "Publier",
+  "comment": "Commenter",
+  "like": "J'aime",
+  "share": "Partager",
+  "follow": "Suivre",
+  "followers": "Abonnés"
+}

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/widgets.dart';
+
+class AppLocalizations {
+  AppLocalizations(this.locale);
+
+  final Locale locale;
+
+  static const supportedLocales = [Locale('en'), Locale('fr')];
+
+  static const _localizedValues = <String, Map<String, String>>{
+    'en': {
+      'appName': 'Fouta',
+      'settings': 'Settings',
+      'privacy': 'Privacy',
+      'save': 'Save',
+      'cancel': 'Cancel',
+      'post': 'Post',
+      'comment': 'Comment',
+      'like': 'Like',
+      'share': 'Share',
+      'follow': 'Follow',
+      'followers': 'Followers',
+    },
+    'fr': {
+      'appName': 'Fouta',
+      'settings': 'Paramètres',
+      'privacy': 'Confidentialité',
+      'save': 'Enregistrer',
+      'cancel': 'Annuler',
+      'post': 'Publier',
+      'comment': 'Commenter',
+      'like': "J'aime",
+      'share': 'Partager',
+      'follow': 'Suivre',
+      'followers': 'Abonnés',
+    },
+  };
+
+  String translate(String key) {
+    return _localizedValues[locale.languageCode]?[key] ??
+        _localizedValues['en']![key] ??
+        key;
+  }
+
+  String get appName => translate('appName');
+  String get settings => translate('settings');
+  String get privacy => translate('privacy');
+  String get save => translate('save');
+  String get cancel => translate('cancel');
+  String get post => translate('post');
+  String get comment => translate('comment');
+  String get like => translate('like');
+  String get share => translate('share');
+  String get follow => translate('follow');
+  String get followers => translate('followers');
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
+}
+
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) {
+    return AppLocalizations.supportedLocales
+        .any((l) => l.languageCode == locale.languageCode);
+  }
+
+  @override
+  Future<AppLocalizations> load(Locale locale) async {
+    return AppLocalizations(locale);
+  }
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}

--- a/test/l10n_keys_test.dart
+++ b/test/l10n_keys_test.dart
@@ -1,0 +1,14 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('l10n files contain same keys', () {
+    final enFile = File('lib/l10n/app_en.arb');
+    final frFile = File('lib/l10n/app_fr.arb');
+    final enKeys = (json.decode(enFile.readAsStringSync()) as Map<String, dynamic>).keys.toSet();
+    final frKeys = (json.decode(frFile.readAsStringSync()) as Map<String, dynamic>).keys.toSet();
+    expect(enKeys, frKeys);
+  });
+}


### PR DESCRIPTION
## Summary
- add English/French ARB files and manual `AppLocalizations` delegate
- introduce dev sandbox with buttons to toggle locales
- document i18n sandbox usage and changelog entry

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: package.json and lock file out of sync)*
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_689c089460f0832bbe42c07f9faf6d02