### PR TITLE
feat(preview): link preview service, card, and demo screen (route-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- 2025-08-12 – Link Preview module + demo screen (route-only).
+
 - 2025-08-12 – Notifications v2: per-type prefs, in-app inbox, batched push.
 
 - 2025-08-12 – Reposts/Quote posts; Saved Collections; Share to Story.

--- a/README.md
+++ b/README.md
@@ -445,3 +445,9 @@ Daily rollups stored at `artifacts/$APP_ID/public/data/metrics/daily/{YYYY-MM-DD
 Fouta sends notifications for follows, comments, likes, reposts, mentions, and messages. Users can manage per-type preferences from the unified settings screen.
 Preferences are stored at `artifacts/$APP_ID/public/data/users/{uid}/settings/notifications` with boolean flags for each type.
 In-app notifications live at `artifacts/$APP_ID/public/data/notifications/{uid}/items` and are marked read when opened.
+
+## Link Preview module
+- Demo route: `/_dev/link-preview`
+- `LinkPreviewService` fetches Open Graph data for URLs.
+- Dev Cloud Function endpoint: `https://<region>-<project>.cloudfunctions.net/openGraph?url=`
+  - Returns JSON `{ title, description, imageUrl, siteName }`

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,3 +3,4 @@ export {
   queueNotification,
   dispatchQueuedNotifications,
 } from './notifyBatched';
+export { openGraph } from './openGraph';

--- a/functions/src/openGraph.ts
+++ b/functions/src/openGraph.ts
@@ -1,0 +1,29 @@
+import * as functions from 'firebase-functions';
+
+export const openGraph = functions.https.onRequest(async (req, res) => {
+  const url = (req.query.url as string | undefined)?.toString().trim() ?? '';
+  if (!/^https?:\/\//i.test(url)) {
+    res.status(400).json({ error: 'invalid-url' });
+    return;
+  }
+  try {
+    const response = await fetch(url);
+    const html = await response.text();
+    const meta = (property: string): string | null => {
+      const regex = new RegExp(
+        `<meta[^>]+property=['\"]${property}['\"][^>]*content=['\"]([^'\"]+)['\"]`,
+        'i',
+      );
+      return regex.exec(html)?.[1] ?? null;
+    };
+    res.json({
+      title: meta('og:title'),
+      description: meta('og:description'),
+      imageUrl: meta('og:image'),
+      siteName: meta('og:site_name'),
+    });
+  } catch (e) {
+    res.status(500).json({ error: 'fetch-failed' });
+  }
+});
+

--- a/lib/devtools/link_preview_demo_screen.dart
+++ b/lib/devtools/link_preview_demo_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../features/link_preview/link_preview_card.dart';
+import '../features/link_preview/link_preview_service.dart';
+
+/// Simple screen to manually test link previews.
+class LinkPreviewDemoScreen extends StatefulWidget {
+  const LinkPreviewDemoScreen({super.key});
+
+  @override
+  State<LinkPreviewDemoScreen> createState() => _LinkPreviewDemoScreenState();
+}
+
+class _LinkPreviewDemoScreenState extends State<LinkPreviewDemoScreen> {
+  final _controller = TextEditingController();
+  final _service = const LinkPreviewService();
+  LinkPreviewData? _data;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _preview() async {
+    final data = await _service.fetch(_controller.text);
+    setState(() => _data = data);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Link Preview Demo')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _controller,
+              decoration: const InputDecoration(labelText: 'URL'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: _preview,
+              child: const Text('Preview'),
+            ),
+            const SizedBox(height: 16),
+            if (_data != null) LinkPreviewCard(data: _data!),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+Map<String, WidgetBuilder> linkPreviewRoutes() =>
+    {'/_dev/link-preview': (_) => const LinkPreviewDemoScreen()};
+

--- a/lib/features/link_preview/link_preview_card.dart
+++ b/lib/features/link_preview/link_preview_card.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+import 'link_preview_service.dart';
+
+/// Displays Open Graph data with safe fallbacks.
+class LinkPreviewCard extends StatelessWidget {
+  const LinkPreviewCard({super.key, required this.data});
+
+  final LinkPreviewData data;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildImage(),
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  data.title,
+                  style: Theme.of(context).textTheme.titleMedium,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (data.description != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      data.description!,
+                      style: Theme.of(context).textTheme.bodySmall,
+                      maxLines: 3,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                if (data.siteName != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      data.siteName!,
+                      style: Theme.of(context).textTheme.labelSmall,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildImage() {
+    if (data.imageUrl == null) {
+      return _placeholder();
+    }
+    return Image.network(
+      data.imageUrl!,
+      height: 150,
+      width: double.infinity,
+      fit: BoxFit.cover,
+      errorBuilder: (_, __, ___) => _placeholder(),
+    );
+  }
+
+  Widget _placeholder() => Container(
+        height: 150,
+        color: Colors.grey.shade300,
+        alignment: Alignment.center,
+        child: const Icon(Icons.link, size: 40, color: Colors.black45),
+      );
+}
+

--- a/lib/features/link_preview/link_preview_service.dart
+++ b/lib/features/link_preview/link_preview_service.dart
@@ -1,0 +1,70 @@
+import 'package:http/http.dart' as http;
+
+/// Data returned by [LinkPreviewService].
+class LinkPreviewData {
+  const LinkPreviewData({
+    required this.title,
+    this.description,
+    this.imageUrl,
+    this.siteName,
+  });
+
+  final String title;
+  final String? description;
+  final String? imageUrl;
+  final String? siteName;
+}
+
+/// Service for fetching Open Graph data for a URL.
+class LinkPreviewService {
+  const LinkPreviewService();
+
+  /// Normalizes [url] and ensures it uses http/https.
+  static String? normalizeUrl(String url) {
+    final trimmed = url.trim();
+    if (trimmed.isEmpty) return null;
+    Uri? uri = Uri.tryParse(trimmed);
+    if (uri == null) return null;
+    if (uri.scheme.isEmpty) {
+      uri = Uri.parse('https://$trimmed');
+    }
+    if (uri.scheme != 'http' && uri.scheme != 'https') return null;
+    return uri.toString();
+  }
+
+  /// Fetches Open Graph metadata for [url].
+  /// Returns null if the URL is invalid or data cannot be fetched.
+  Future<LinkPreviewData?> fetch(String url) async {
+    final normalized = normalizeUrl(url);
+    if (normalized == null) return null;
+    try {
+      final resp = await http.get(Uri.parse(normalized));
+      if (resp.statusCode != 200) return null;
+      final html = resp.body;
+      String? _meta(String property) {
+        final exp = RegExp(
+          '<meta[^>]+property=["\']$property["\'][^>]*content=["\']([^"\']+)["\']',
+          caseSensitive: false,
+        );
+        return exp.firstMatch(html)?.group(1);
+      }
+
+      String? title = _meta('og:title') ?? _titleFromHtml(html);
+      if (title == null) return null;
+      return LinkPreviewData(
+        title: title,
+        description: _meta('og:description'),
+        imageUrl: _meta('og:image'),
+        siteName: _meta('og:site_name') ?? Uri.parse(normalized).host,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static String? _titleFromHtml(String html) {
+    final exp = RegExp('<title>([^<]*)</title>', caseSensitive: false);
+    return exp.firstMatch(html)?.group(1);
+  }
+}
+

--- a/test/link_preview_card_test.dart
+++ b/test/link_preview_card_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/features/link_preview/link_preview_card.dart';
+import 'package:fouta_app/features/link_preview/link_preview_service.dart';
+
+void main() {
+  testWidgets('shows placeholder when image is missing', (tester) async {
+    final data = LinkPreviewData(title: 'Example', description: 'Desc');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: LinkPreviewCard(data: data),
+        ),
+      ),
+    );
+    expect(find.byIcon(Icons.link), findsOneWidget);
+  });
+}

--- a/test/link_preview_service_test.dart
+++ b/test/link_preview_service_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/features/link_preview/link_preview_service.dart';
+
+void main() {
+  group('LinkPreviewService.normalizeUrl', () {
+    test('adds https scheme when missing', () {
+      expect(
+        LinkPreviewService.normalizeUrl('example.com'),
+        'https://example.com',
+      );
+    });
+
+    test('trims whitespace', () {
+      expect(
+        LinkPreviewService.normalizeUrl(' https://foo.com '),
+        'https://foo.com',
+      );
+    });
+
+    test('rejects non-http schemes', () {
+      expect(LinkPreviewService.normalizeUrl('ftp://foo.com'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add LinkPreviewService with URL normalization and Open Graph parsing
- present data via LinkPreviewCard and demo screen `/_dev/link-preview`
- document dev-only openGraph Cloud Function

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: lockfile out of sync)*
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_689c08c27758832b8bd52b35b2daeb17