### PR TITLE
fix(build): resolve const ctor misuse, trending chips state, stories type, chat status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@
 - 2025-08-12 – Project policy update: allow branch creation/switching and new dependencies with DEP records. If branch switching was forbidden by runtime, changes were committed directly to `dev` (fallback).
 
 - 2025-08-12 – Safety & Privacy v2: mute words, reply limits, private account, block/mute manager (route-only).
+- 2025-08-12 – Fix compile errors: Shorts route const call; trending chips state; stories type; chat upload progress param; message status helper; non-const constructors in events screens.

--- a/README.md
+++ b/README.md
@@ -495,3 +495,7 @@ Data models are stored under `artifacts/\$APP_ID/public/data/users/{uid}/safety`
 - `muted_words` document field:
   - `words` (`List<String>`; lowercased)
 
+## Troubleshooting
+
+If constructors use non-const initializers (e.g., FirebaseAuth, service instances), remove const from widget constructors.
+

--- a/lib/screens/event_detail_screen.dart
+++ b/lib/screens/event_detail_screen.dart
@@ -4,18 +4,19 @@ import 'package:flutter/material.dart';
 import '../features/events/events_service.dart';
 
 class EventDetailScreen extends StatefulWidget {
-  const EventDetailScreen({
-    super.key,
+  final Event event;
+  final EventsService service;
+  final String currentUserId;
+
+  EventDetailScreen({
+    Key? key,
     required this.event,
     EventsService? service,
     String? currentUserId,
   })  : service = service ?? EventsService(),
         currentUserId =
-            currentUserId ?? FirebaseAuth.instance.currentUser?.uid ?? '';
-
-  final Event event;
-  final EventsService service;
-  final String currentUserId;
+            currentUserId ?? FirebaseAuth.instance.currentUser?.uid ?? '',
+        super(key: key);
 
   @override
   State<EventDetailScreen> createState() => _EventDetailScreenState();

--- a/lib/screens/events_list_screen.dart
+++ b/lib/screens/events_list_screen.dart
@@ -5,13 +5,17 @@ import '../features/events/events_service.dart';
 import 'event_detail_screen.dart';
 
 class EventsListScreen extends StatefulWidget {
-  const EventsListScreen({super.key, EventsService? service, String? currentUserId})
-      : service = service ?? EventsService(),
-        currentUserId =
-            currentUserId ?? FirebaseAuth.instance.currentUser?.uid ?? '';
-
   final EventsService service;
   final String currentUserId;
+
+  EventsListScreen({
+    Key? key,
+    EventsService? service,
+    String? currentUserId,
+  })  : service = service ?? EventsService(),
+        currentUserId =
+            currentUserId ?? FirebaseAuth.instance.currentUser?.uid ?? '',
+        super(key: key);
 
   @override
   State<EventsListScreen> createState() => _EventsListScreenState();

--- a/lib/widgets/trending_tags_bar.dart
+++ b/lib/widgets/trending_tags_bar.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class TrendingChipBar extends StatelessWidget {
-  const TrendingChipBar({
+class TrendingTagsBar extends StatelessWidget {
+  const TrendingTagsBar({
     super.key,
     required this.tags,
     required this.onSelected,
@@ -9,7 +9,7 @@ class TrendingChipBar extends StatelessWidget {
   });
 
   final List<String> tags;
-  final ValueChanged<String> onSelected;
+  final ValueChanged<String?> onSelected;
   final String? selectedTag;
 
   @override
@@ -25,7 +25,8 @@ class TrendingChipBar extends StatelessWidget {
                   child: ChoiceChip(
                     label: Text('#$t'),
                     selected: selectedTag == t,
-                    onSelected: (_) => onSelected(t),
+                    onSelected: (_) =>
+                        onSelected(selectedTag == t ? null : t),
                   ),
                 ))
             .toList(),

--- a/test/widgets/trending_tags_bar_test.dart
+++ b/test/widgets/trending_tags_bar_test.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:fouta_app/widgets/trending_chip_bar.dart';
+import 'package:fouta_app/widgets/trending_tags_bar.dart';
 
 void main() {
-  testWidgets('TrendingChipBar renders and handles tap', (tester) async {
+  testWidgets('TrendingTagsBar renders and handles tap', (tester) async {
     String? tapped;
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: TrendingChipBar(
+          body: TrendingTagsBar(
             tags: const ['one', 'two'],
             selectedTag: null,
             onSelected: (t) => tapped = t,


### PR DESCRIPTION
## Summary
- remove const misuses in events screens and home shorts route
- wire trending tags state, story mapping, and chat message status helper
- drop unsupported upload progress callback

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `flutter build web --release` *(fails: command not found)*
- `flutter build apk --debug` *(fails: command not found)*
- `npm ci` *(fails: lock file mismatch)*
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_689c0fe198fc832bbfcb6db05ca2e4e7