### PR TITLE
fix(build): remove invalid const usage for EventsListScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@
 
 - 2025-08-12 – Safety & Privacy v2: mute words, reply limits, private account, block/mute manager (route-only).
 - 2025-08-12 – Fix compile errors: Shorts route const call; trending chips state; stories type; chat upload progress param; message status helper; non-const constructors in events screens.
+- 2025-08-12 – Fix: remove invalid `const` usage for EventsListScreen in home_screen.dart; adjust const lists if present.

--- a/README.md
+++ b/README.md
@@ -498,4 +498,5 @@ Data models are stored under `artifacts/\$APP_ID/public/data/users/{uid}/safety`
 ## Troubleshooting
 
 If constructors use non-const initializers (e.g., FirebaseAuth, service instances), remove const from widget constructors.
+If a widget constructor uses services/auth in initializers, don’t construct it with const or place it inside a const list.
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -293,7 +293,7 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
                         ChatsTab(
                             setNavBarVisibility: _setNavBarVisibility,
                             setShowNewChatFab: _setShowNewChatFab)),
-                    _buildTabNavigator(2, const EventsListScreen()),
+                    _buildTabNavigator(2, EventsListScreen()),
                     _buildTabNavigator(3, const PeopleTab()),
                     _buildTabNavigator(
                         4, ProfileScreen(userId: currentUser?.uid ?? '')),


### PR DESCRIPTION
## Summary
- remove `const` from `EventsListScreen` usage in home tab navigation
- document avoiding `const` for widgets with service/auth initializers

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: package.json and lockfile out of sync)*
- `npm test --if-present`
- `flutter run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c13a83f10832bb92c25ab25d9b39e