### PR TITLE
feat(nav,lists): transitions, refresh scaffold, paging controller, placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 
+- 2025-08-12 – Nav transitions & List UX: refresh, paging, empty/error states. (Committed on fallback branch `work` due to branch creation restrictions.)
 - 2025-08-12 – Composer V2: drafts & scheduling (route-only).
 - 2025-08-12 – Link Preview module + demo screen (route-only).
 - 2025-08-12 – i18n scaffolding (EN/FR) with dev sandbox; no app wiring yet.

--- a/README.md
+++ b/README.md
@@ -500,3 +500,5 @@ Data models are stored under `artifacts/\$APP_ID/public/data/users/{uid}/safety`
 If constructors use non-const initializers (e.g., FirebaseAuth, service instances), remove const from widget constructors.
 If a widget constructor uses services/auth in initializers, don’t construct it with const or place it inside a const list.
 
+
+## Navigation & List UX Utilities

--- a/lib/navigation/motion.dart
+++ b/lib/navigation/motion.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/animation.dart';
+
+/// Standard motion durations and curves for Fouta transitions.
+class FoutaMotion {
+  static const Duration duration = Duration(milliseconds: 300);
+  static const Curve curve = Curves.easeInOut;
+}

--- a/lib/navigation/transitions.dart
+++ b/lib/navigation/transitions.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import 'motion.dart';
+
+/// Reusable page transitions for the app.
+class FoutaTransitions {
+  /// Slides [child] in from the right.
+  static PageRouteBuilder<T> pushFromRight<T>(Widget child) {
+    return PageRouteBuilder<T>(
+      pageBuilder: (_, __, ___) => child,
+      transitionDuration: FoutaMotion.duration,
+      transitionsBuilder: (_, animation, __, child) {
+        final offsetAnimation = Tween<Offset>(
+          begin: const Offset(1, 0),
+          end: Offset.zero,
+        ).animate(CurvedAnimation(parent: animation, curve: FoutaMotion.curve));
+        return SlideTransition(position: offsetAnimation, child: child);
+      },
+    );
+  }
+
+  /// Fades [child] in.
+  static PageRouteBuilder<T> fadeIn<T>(Widget child) {
+    return PageRouteBuilder<T>(
+      pageBuilder: (_, __, ___) => child,
+      transitionDuration: FoutaMotion.duration,
+      transitionsBuilder: (_, animation, __, child) {
+        final fade = CurvedAnimation(parent: animation, curve: FoutaMotion.curve);
+        return FadeTransition(opacity: fade, child: child);
+      },
+    );
+  }
+
+  /// Scales [child] in.
+  static PageRouteBuilder<T> scaleIn<T>(Widget child) {
+    return PageRouteBuilder<T>(
+      pageBuilder: (_, __, ___) => child,
+      transitionDuration: FoutaMotion.duration,
+      transitionsBuilder: (_, animation, __, child) {
+        final scale = Tween<double>(begin: 0.9, end: 1)
+            .animate(CurvedAnimation(parent: animation, curve: FoutaMotion.curve));
+        return ScaleTransition(scale: scale, child: child);
+      },
+    );
+  }
+}

--- a/lib/utils/paging_controller.dart
+++ b/lib/utils/paging_controller.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/widgets.dart';
+
+/// Controller that triggers [onLoadMore] when the user scrolls near the bottom.
+class PagingController {
+  final Future<void> Function() onLoadMore;
+  final double threshold;
+  final ScrollController scrollController;
+
+  bool _loading = false;
+  bool _triggered = false;
+
+  PagingController({
+    required this.onLoadMore,
+    this.threshold = 200,
+    ScrollController? scrollController,
+  }) : scrollController = scrollController ?? ScrollController() {
+    this.scrollController.addListener(_onScroll);
+  }
+
+  void _onScroll() {
+    final position = scrollController.position;
+    if (!_loading && !_triggered && position.extentAfter < threshold) {
+      _loading = true;
+      _triggered = true;
+      onLoadMore().whenComplete(() => _loading = false);
+    }
+  }
+
+  /// Allows another load once new data has been appended.
+  void reset() {
+    _triggered = false;
+  }
+
+  void dispose() {
+    scrollController.removeListener(_onScroll);
+    scrollController.dispose();
+  }
+}

--- a/lib/widgets/refresh_scaffold.dart
+++ b/lib/widgets/refresh_scaffold.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+/// Scaffold that wraps a [CustomScrollView] with pull-to-refresh and
+/// empty/error state handling.
+class RefreshScaffold extends StatelessWidget {
+  final RefreshCallback onRefresh;
+  final List<Widget> slivers;
+  final Widget? empty;
+  final Widget? error;
+
+  const RefreshScaffold({
+    super.key,
+    required this.onRefresh,
+    required this.slivers,
+    this.empty,
+    this.error,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    List<Widget> content = slivers;
+    if (error != null) {
+      content = [SliverFillRemaining(hasScrollBody: false, child: error!)];
+    } else if (empty != null && slivers.isEmpty) {
+      content = [SliverToBoxAdapter(child: empty!)];
+    }
+
+    return RefreshIndicator(
+      onRefresh: onRefresh,
+      child: CustomScrollView(slivers: content),
+    );
+  }
+}

--- a/lib/widgets/state_placeholders.dart
+++ b/lib/widgets/state_placeholders.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+/// Generic empty state widget.
+class EmptyState extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String message;
+  final Widget? cta;
+
+  const EmptyState({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.message,
+    this.cta,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 48),
+          const SizedBox(height: 8),
+          Text(title, style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 4),
+          Text(message, textAlign: TextAlign.center),
+          if (cta != null) ...[
+            const SizedBox(height: 16),
+            cta!,
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// Generic error state widget.
+class ErrorState extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String message;
+  final Widget? cta;
+
+  const ErrorState({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.message,
+    this.cta,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return EmptyState(icon: icon, title: title, message: message, cta: cta);
+  }
+}

--- a/test/paging_controller_test.dart
+++ b/test/paging_controller_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/utils/paging_controller.dart';
+
+void main() {
+  testWidgets('threshold triggers only once per page', (tester) async {
+    int calls = 0;
+    final paging = PagingController(onLoadMore: () async {
+      calls++;
+    });
+
+    await tester.pumpWidget(MaterialApp(
+      home: ListView.builder(
+        controller: paging.scrollController,
+        itemCount: 20,
+        itemBuilder: (_, i) => const SizedBox(height: 100),
+      ),
+    ));
+
+    paging.scrollController.jumpTo(
+      paging.scrollController.position.maxScrollExtent,
+    );
+    await tester.pump();
+    expect(calls, 1);
+
+    paging.scrollController.jumpTo(
+      paging.scrollController.position.maxScrollExtent,
+    );
+    await tester.pump();
+    expect(calls, 1);
+
+    paging.reset();
+    paging.scrollController.jumpTo(
+      paging.scrollController.position.maxScrollExtent,
+    );
+    await tester.pump();
+    expect(calls, 2);
+
+    paging.dispose();
+  });
+}

--- a/test/refresh_scaffold_test.dart
+++ b/test/refresh_scaffold_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/widgets/refresh_scaffold.dart';
+
+void main() {
+  testWidgets('pull-to-refresh callback invocation', (tester) async {
+    int refreshes = 0;
+
+    await tester.pumpWidget(MaterialApp(
+      home: RefreshScaffold(
+        onRefresh: () async {
+          refreshes++;
+        },
+        slivers: const [
+          SliverToBoxAdapter(child: SizedBox(height: 1000)),
+        ],
+      ),
+    ));
+
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, 300));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(refreshes, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- add standard motion constants and navigation transitions
- introduce RefreshScaffold with empty/error slots
- add PagingController for load-more and reusable state placeholders

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: package.json and lock file out of sync)*
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_689c179b5ef4832baea8ec8300a76d53