### PR TITLE
feat(ui): animated like/bookmark buttons and reaction tray (reusable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 
+- 2025-08-12 – Micro-interactions: animated like/bookmark, reaction tray.
 - 2025-08-12 – Composer V2: drafts & scheduling (route-only).
 - 2025-08-12 – Link Preview module + demo screen (route-only).
 - 2025-08-12 – i18n scaffolding (EN/FR) with dev sandbox; no app wiring yet.

--- a/README.md
+++ b/README.md
@@ -500,3 +500,23 @@ Data models are stored under `artifacts/\$APP_ID/public/data/users/{uid}/safety`
 If constructors use non-const initializers (e.g., FirebaseAuth, service instances), remove const from widget constructors.
 If a widget constructor uses services/auth in initializers, don’t construct it with const or place it inside a const list.
 
+
+### Micro-interaction widgets
+
+```dart
+AnimatedLikeButton(
+  isLiked: false,
+  onChanged: (liked) {},
+);
+
+AnimatedBookmarkButton(
+  isSaved: false,
+  onChanged: (saved) {},
+);
+
+ReactionTray(
+  onReactionSelected: (reaction) {
+    // handle ReactionType
+  },
+);
+```

--- a/lib/utils/haptics.dart
+++ b/lib/utils/haptics.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+class Haptics {
+  const Haptics._();
+
+  static Future<void> light() async {
+    if (kIsWeb) return;
+    await HapticFeedback.lightImpact();
+  }
+
+  static Future<void> medium() async {
+    if (kIsWeb) return;
+    await HapticFeedback.mediumImpact();
+  }
+
+  static Future<void> success() async {
+    if (kIsWeb) return;
+    await HapticFeedback.heavyImpact();
+  }
+}

--- a/lib/widgets/animated_bookmark_button.dart
+++ b/lib/widgets/animated_bookmark_button.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+
+import '../utils/haptics.dart';
+
+class AnimatedBookmarkButton extends StatefulWidget {
+  const AnimatedBookmarkButton({
+    super.key,
+    required this.isSaved,
+    required this.onChanged,
+  });
+
+  final bool isSaved;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  State<AnimatedBookmarkButton> createState() => _AnimatedBookmarkButtonState();
+}
+
+class _AnimatedBookmarkButtonState extends State<AnimatedBookmarkButton>
+    with SingleTickerProviderStateMixin {
+  late bool _saved;
+  bool _pressed = false;
+  late final AnimationController _checkmarkController;
+
+  @override
+  void initState() {
+    super.initState();
+    _saved = widget.isSaved;
+    _checkmarkController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant AnimatedBookmarkButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.isSaved != widget.isSaved) {
+      _saved = widget.isSaved;
+    }
+  }
+
+  @override
+  void dispose() {
+    _checkmarkController.dispose();
+    super.dispose();
+  }
+
+  void _toggle() {
+    setState(() => _saved = !_saved);
+    if (_saved) {
+      _checkmarkController.forward(from: 0);
+      Haptics.success();
+    } else {
+      Haptics.medium();
+    }
+    widget.onChanged(_saved);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final icon = _saved ? Icons.bookmark : Icons.bookmark_border;
+    final label = _saved ? 'Remove bookmark' : 'Bookmark';
+
+    final checkmark = FadeTransition(
+      opacity: _checkmarkController.drive(CurveTween(curve: Curves.easeOut)),
+      child: ScaleTransition(
+        scale: _checkmarkController.drive(CurveTween(curve: Curves.easeOut)),
+        child: const Icon(Icons.check, color: Colors.green),
+      ),
+    );
+
+    return Semantics(
+      button: true,
+      label: label,
+      toggled: _saved,
+      child: GestureDetector(
+        onTapDown: (_) => setState(() => _pressed = true),
+        onTapCancel: () => setState(() => _pressed = false),
+        onTapUp: (_) {
+          setState(() => _pressed = false);
+          _toggle();
+        },
+        child: AnimatedScale(
+          scale: _pressed ? 0.94 : 1.0,
+          duration: const Duration(milliseconds: 100),
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              Icon(icon),
+              if (_saved) checkmark,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/animated_like_button.dart
+++ b/lib/widgets/animated_like_button.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+
+import '../utils/haptics.dart';
+
+class AnimatedLikeButton extends StatefulWidget {
+  const AnimatedLikeButton({
+    super.key,
+    required this.isLiked,
+    required this.onChanged,
+  });
+
+  final bool isLiked;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  State<AnimatedLikeButton> createState() => _AnimatedLikeButtonState();
+}
+
+class _AnimatedLikeButtonState extends State<AnimatedLikeButton>
+    with SingleTickerProviderStateMixin {
+  late bool _liked;
+  bool _pressed = false;
+  late final AnimationController _controller;
+  late final Animation<double> _burst;
+
+  @override
+  void initState() {
+    super.initState();
+    _liked = widget.isLiked;
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+    _burst = TweenSequence<double>([
+      TweenSequenceItem(
+        tween: Tween(begin: 1.0, end: 1.2)
+            .chain(CurveTween(curve: Curves.easeOut)),
+        weight: 50,
+      ),
+      TweenSequenceItem(
+        tween: Tween(begin: 1.2, end: 1.0)
+            .chain(CurveTween(curve: Curves.easeIn)),
+        weight: 50,
+      ),
+    ]).animate(_controller);
+  }
+
+  @override
+  void didUpdateWidget(covariant AnimatedLikeButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.isLiked != widget.isLiked) {
+      _liked = widget.isLiked;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _toggle() {
+    setState(() => _liked = !_liked);
+    if (_liked) {
+      _controller.forward(from: 0);
+    }
+    Haptics.light();
+    widget.onChanged(_liked);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final icon = _liked ? Icons.favorite : Icons.favorite_border;
+    final color = _liked ? Colors.red : null;
+    final label = _liked ? 'Unlike' : 'Like';
+
+    return Semantics(
+      button: true,
+      label: label,
+      toggled: _liked,
+      child: GestureDetector(
+        onTapDown: (_) => setState(() => _pressed = true),
+        onTapCancel: () => setState(() => _pressed = false),
+        onTapUp: (_) {
+          setState(() => _pressed = false);
+          _toggle();
+        },
+        child: AnimatedScale(
+          scale: _pressed ? 0.94 : 1.0,
+          duration: const Duration(milliseconds: 100),
+          child: AnimatedBuilder(
+            animation: _controller,
+            builder: (context, child) => Transform.scale(
+              scale: _liked ? _burst.value : 1.0,
+              child: child,
+            ),
+            child: Icon(icon, color: color),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/reaction_tray.dart
+++ b/lib/widgets/reaction_tray.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+import '../utils/haptics.dart';
+
+enum ReactionType { like, love, haha, wow, sad, angry }
+
+typedef ReactionSelected = void Function(ReactionType type);
+
+class ReactionTray extends StatefulWidget {
+  const ReactionTray({
+    super.key,
+    required this.onReactionSelected,
+  });
+
+  final ReactionSelected onReactionSelected;
+
+  @override
+  State<ReactionTray> createState() => _ReactionTrayState();
+}
+
+class _ReactionTrayState extends State<ReactionTray> {
+  bool _expanded = false;
+  int? _activeIndex;
+  static const _emojis = ['👍', '❤️', '😂', '😮', '😢', '😡'];
+
+  void _select(int index) {
+    widget.onReactionSelected(ReactionType.values[index]);
+    Haptics.light();
+    setState(() {
+      _expanded = false;
+      _activeIndex = null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onLongPress: () => setState(() => _expanded = true),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        height: 40,
+        width: _expanded ? 240 : 40,
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        decoration: BoxDecoration(
+          color: Colors.black.withOpacity(0.1),
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: _expanded
+            ? Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: List.generate(_emojis.length, (index) {
+                  final emoji = _emojis[index];
+                  final active = _activeIndex == index;
+                  return MouseRegion(
+                    onEnter: (_) => setState(() => _activeIndex = index),
+                    onExit: (_) => setState(() => _activeIndex = null),
+                    child: GestureDetector(
+                      onTapDown: (_) => setState(() => _activeIndex = index),
+                      onTapCancel: () => setState(() => _activeIndex = null),
+                      onTapUp: (_) => _select(index),
+                      child: AnimatedScale(
+                        scale: active ? 1.4 : 1.0,
+                        duration: const Duration(milliseconds: 100),
+                        child: Text(emoji, style: const TextStyle(fontSize: 24)),
+                      ),
+                    ),
+                  );
+                }),
+              )
+            : const Center(child: Text('👍', style: TextStyle(fontSize: 24))),
+      ),
+    );
+  }
+}

--- a/test/widgets/animated_bookmark_button_test.dart
+++ b/test/widgets/animated_bookmark_button_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fouta_app/widgets/animated_bookmark_button.dart';
+
+void main() {
+  testWidgets('AnimatedBookmarkButton toggles and shows checkmark', (tester) async {
+    var saved = false;
+    await tester.pumpWidget(MaterialApp(
+      home: AnimatedBookmarkButton(
+        isSaved: saved,
+        onChanged: (v) => saved = v,
+      ),
+    ));
+
+    expect(find.byIcon(Icons.bookmark_border), findsOneWidget);
+
+    await tester.tap(find.byType(AnimatedBookmarkButton));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(saved, isTrue);
+    expect(find.byIcon(Icons.bookmark), findsOneWidget);
+  });
+}

--- a/test/widgets/animated_like_button_test.dart
+++ b/test/widgets/animated_like_button_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fouta_app/widgets/animated_like_button.dart';
+
+void main() {
+  testWidgets('AnimatedLikeButton toggles and animates', (tester) async {
+    var liked = false;
+    await tester.pumpWidget(MaterialApp(
+      home: AnimatedLikeButton(
+        isLiked: liked,
+        onChanged: (v) => liked = v,
+      ),
+    ));
+
+    expect(find.byIcon(Icons.favorite_border), findsOneWidget);
+
+    await tester.tap(find.byType(AnimatedLikeButton));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(liked, isTrue);
+    expect(find.byIcon(Icons.favorite), findsOneWidget);
+  });
+}

--- a/test/widgets/reaction_tray_test.dart
+++ b/test/widgets/reaction_tray_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fouta_app/widgets/reaction_tray.dart';
+
+void main() {
+  testWidgets('ReactionTray returns selection', (tester) async {
+    ReactionType? selected;
+    await tester.pumpWidget(MaterialApp(
+      home: ReactionTray(onReactionSelected: (r) => selected = r),
+    ));
+
+    await tester.longPress(find.byType(ReactionTray));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('❤️'));
+    await tester.pump();
+
+    expect(selected, ReactionType.love);
+  });
+}


### PR DESCRIPTION
## Summary
- add Haptics utility for light/medium/success feedback
- add animated like & bookmark buttons with press scale and toggle animations
- introduce reaction tray for emoji reactions

## Risks
- animation controllers may leak if not disposed properly
- scaling interactions may feel slow on low-end devices
- reaction tray long-press may conflict with other gestures
- haptic feedback may not be supported on all platforms
- added tests might require Flutter environment setup

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `(cd functions && npm ci)` *(fails: lock file out of sync)*
- `(cd functions && npm test --if-present)` *(no tests run)*


------
https://chatgpt.com/codex/tasks/task_e_689c17ac9290832ba340f2dfa5233e64