### PR TITLE
feat(stability): safe builders, async guards, error reporter stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 
+- 2025-08-12 – Stability: safe stream/future builders, async guards, error reporter stub.
 - 2025-08-12 – Composer V2: drafts & scheduling (route-only).
 - 2025-08-12 – Link Preview module + demo screen (route-only).
 - 2025-08-12 – i18n scaffolding (EN/FR) with dev sandbox; no app wiring yet.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [Monetization](#monetization)
 - [Admin Analytics](#admin-analytics)
 - [Notifications](#notifications)
+- [Stability Utilities](#stability-utilities)
 
 - [Composer V2 (route /composeV2)](#composer-v2-route-composev2)
 
@@ -462,6 +463,9 @@ Preferences are stored at `artifacts/$APP_ID/public/data/users/{uid}/settings/no
 In-app notifications live at `artifacts/$APP_ID/public/data/notifications/{uid}/items` and are marked read when opened.
 
 
+
+## Stability Utilities
+Reusable helpers ensure widgets and async code fail gracefully.
 
 ## Composer V2 (route /composeV2)
 Experimental composer supporting drafts and scheduled posts.

--- a/lib/utils/async_guard.dart
+++ b/lib/utils/async_guard.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:fouta_app/utils/error_reporter.dart';
+
+/// Guards state updates to run only when the [State] is still mounted.
+void mountedSetState(State state, VoidCallback fn) {
+  if (!state.mounted) return;
+  state.setState(fn);
+}
+
+/// Runs [op] and reports any thrown errors.
+///
+/// If an error occurs, it is reported and rethrown. Optionally, an [onError]
+/// callback can handle the error before it is rethrown.
+Future<T> guardAsync<T>(Future<T> Function() op,
+    {Function(Object, StackTrace)? onError}) async {
+  try {
+    return await op();
+  } catch (e, st) {
+    ErrorReporter.report(e, st);
+    if (onError != null) onError(e, st);
+    rethrow;
+  }
+}

--- a/lib/utils/error_reporter.dart
+++ b/lib/utils/error_reporter.dart
@@ -1,0 +1,14 @@
+import 'dart:developer' as developer;
+
+/// Centralized error reporting stub.
+///
+/// Logs the [error] with a timestamp. Integration points for services
+/// like Crashlytics or Sentry can be added later.
+class ErrorReporter {
+  /// Report an [error] and optional [stackTrace].
+  static void report(Object error, [StackTrace? stackTrace]) {
+    final String ts = DateTime.now().toIso8601String();
+    developer.log('[' + ts + '] ' + error.toString(), stackTrace: stackTrace);
+    // TODO: Hook into Crashlytics or Sentry.
+  }
+}

--- a/lib/widgets/error_state.dart
+++ b/lib/widgets/error_state.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+/// Basic error UI used by safe builders.
+class ErrorState extends StatelessWidget {
+  final String message;
+
+  const ErrorState({super.key, this.message = 'Something went wrong.'});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        message,
+        style: Theme.of(context).textTheme.bodyMedium,
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+}

--- a/lib/widgets/safe_future_builder.dart
+++ b/lib/widgets/safe_future_builder.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:fouta_app/utils/error_reporter.dart';
+import 'package:fouta_app/widgets/error_state.dart';
+
+/// A [FutureBuilder] wrapper that guards against build errors and future
+/// exceptions.
+///
+/// Example:
+/// ```dart
+/// import 'package:fouta_app/utils/json_safety.dart';
+///
+/// SafeFutureBuilder<Map<String, dynamic>>(
+///   future: fetch(),
+///   builder: (context, snapshot) {
+///     final count = asInt(snapshot.data?['count']);
+///     return Text('$count');
+///   },
+/// );
+/// ```
+class SafeFutureBuilder<T> extends StatelessWidget {
+  final Future<T> future;
+  final AsyncWidgetBuilder<T> builder;
+  final Widget? empty;
+  final void Function(Object error, StackTrace? stackTrace)? onError;
+
+  const SafeFutureBuilder({
+    super.key,
+    required this.future,
+    required this.builder,
+    this.empty,
+    this.onError,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<T>(
+      future: future,
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          onError?.call(snapshot.error!, snapshot.stackTrace);
+          ErrorReporter.report(snapshot.error!, snapshot.stackTrace);
+          return const ErrorState();
+        }
+        if (!snapshot.hasData) {
+          return empty ?? const SizedBox.shrink();
+        }
+        try {
+          return builder(context, snapshot);
+        } catch (e, st) {
+          onError?.call(e, st);
+          ErrorReporter.report(e, st);
+          return const ErrorState();
+        }
+      },
+    );
+  }
+}

--- a/lib/widgets/safe_stream_builder.dart
+++ b/lib/widgets/safe_stream_builder.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:fouta_app/utils/error_reporter.dart';
+import 'package:fouta_app/widgets/error_state.dart';
+
+/// A [StreamBuilder] wrapper that guards against build errors and stream
+/// exceptions.
+///
+/// Example:
+/// ```dart
+/// import 'package:fouta_app/utils/json_safety.dart';
+///
+/// SafeStreamBuilder<Map<String, dynamic>>(
+///   stream: stream,
+///   builder: (context, snapshot) {
+///     final count = asInt(snapshot.data?['count']);
+///     return Text('$count');
+///   },
+/// );
+/// ```
+class SafeStreamBuilder<T> extends StatelessWidget {
+  final Stream<T> stream;
+  final AsyncWidgetBuilder<T> builder;
+  final Widget? empty;
+  final void Function(Object error, StackTrace? stackTrace)? onError;
+
+  const SafeStreamBuilder({
+    super.key,
+    required this.stream,
+    required this.builder,
+    this.empty,
+    this.onError,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<T>(
+      stream: stream,
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          onError?.call(snapshot.error!, snapshot.stackTrace);
+          ErrorReporter.report(snapshot.error!, snapshot.stackTrace);
+          return const ErrorState();
+        }
+        if (!snapshot.hasData) {
+          return empty ?? const SizedBox.shrink();
+        }
+        try {
+          return builder(context, snapshot);
+        } catch (e, st) {
+          onError?.call(e, st);
+          ErrorReporter.report(e, st);
+          return const ErrorState();
+        }
+      },
+    );
+  }
+}

--- a/test/async_guard_test.dart
+++ b/test/async_guard_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/utils/async_guard.dart';
+
+class _Dummy extends StatefulWidget {
+  const _Dummy({super.key});
+
+  @override
+  _DummyState createState() => _DummyState();
+}
+
+class _DummyState extends State<_Dummy> {
+  int count = 0;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+void main() {
+  testWidgets('mountedSetState no-op when unmounted', (tester) async {
+    await tester.pumpWidget(const _Dummy());
+    final _DummyState state = tester.state(find.byType(_Dummy));
+    await tester.pumpWidget(const SizedBox());
+    mountedSetState(state, () {
+      state.count++;
+    });
+    expect(state.count, 0);
+  });
+
+  test('guardAsync catches and surfaces errors', () async {
+    Object? seen;
+    Future<void> run() => guardAsync<void>(() async {
+          throw StateError('boom');
+        }, onError: (e, st) {
+          seen = e;
+        });
+
+    await expectLater(run(), throwsA(isA<StateError>()));
+    expect(seen, isA<StateError>());
+  });
+}

--- a/test/widgets/safe_stream_builder_test.dart
+++ b/test/widgets/safe_stream_builder_test.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/widgets/error_state.dart';
+import 'package:fouta_app/widgets/safe_stream_builder.dart';
+
+void main() {
+  testWidgets('SafeStreamBuilder shows error UI when builder throws',
+      (tester) async {
+    final controller = StreamController<int>();
+    await tester.pumpWidget(MaterialApp(
+      home: SafeStreamBuilder<int>(
+        stream: controller.stream,
+        builder: (context, snapshot) {
+          throw Exception('boom');
+        },
+      ),
+    ));
+
+    controller.add(1);
+    await tester.pump();
+
+    expect(find.byType(ErrorState), findsOneWidget);
+    await controller.close();
+  });
+}


### PR DESCRIPTION
## Summary
- add safe stream & future builders with ErrorState fallback and error callback
- add async guard utilities and central error reporter
- document stability utilities and update changelog

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm install`
- `npm test --if-present`

------
https://chatgpt.com/codex/tasks/task_e_689c17c43b24832b86c3dbbd05ba27c3