### PR TITLE
feat(integration): accessibility focus, text scale, reduced-motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 
 
+- 2025-08-12 – Integration Pass 3: focus visuals, textScale guardrails, reduced-motion fallbacks. (Committed on fallback branch `work` due to branch creation restrictions.)
 - 2025-08-12 – Micro-interactions: animated like/bookmark, reaction tray.
 - 2025-08-12 – Stability: safe stream/future builders, async guards, error reporter stub.
 - 2025-08-12 – Nav transitions & List UX: refresh, paging, empty/error states. (Committed on fallback branch `work` due to branch creation restrictions.)

--- a/README.md
+++ b/README.md
@@ -540,3 +540,7 @@ ReactionTray(
 
 ## Navigation & List UX Utilities
 
+## Accessibility & Motion
+
+The app adopts focus visuals for keyboard users, clamps text scaling to a sensible maximum, and shortens or skips animations when the operating system requests reduced motion. Adjust text size or motion preferences in your device's accessibility settings to toggle these features.
+

--- a/lib/features/marketplace/product_card.dart
+++ b/lib/features/marketplace/product_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'marketplace_service.dart';
+import 'package:fouta_app/theme/tokens.dart';
 
 class ProductCard extends StatelessWidget {
   const ProductCard({
@@ -25,6 +26,7 @@ class ProductCard extends StatelessWidget {
       clipBehavior: Clip.hardEdge,
       child: InkWell(
         onTap: onTap,
+        focusColor: AppColors.primary.withOpacity(0.3),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -33,7 +35,10 @@ class ProductCard extends StatelessWidget {
                 children: [
                   Positioned.fill(
                     child: image != null
-                        ? Image.network(image, width: double.infinity, fit: BoxFit.cover)
+                        ? Semantics(
+                            label: 'Product image: ${product.title}',
+                            child: Image.network(image, width: double.infinity, fit: BoxFit.cover),
+                          )
                         : Container(
                             color: Colors.grey.shade300,
                             child: const Icon(Icons.image, size: 48),
@@ -59,6 +64,7 @@ class ProductCard extends StatelessWidget {
                 product.title,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
+                softWrap: false,
               ),
             ),
             Padding(
@@ -67,11 +73,15 @@ class ProductCard extends StatelessWidget {
             ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              child: GestureDetector(
+              child: InkWell(
                 onTap: onSellerTap,
+                focusColor: AppColors.primary.withOpacity(0.3),
                 child: Text(
                   product.sellerId,
                   style: Theme.of(context).textTheme.bodySmall,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  softWrap: false,
                 ),
               ),
             ),

--- a/lib/screens/marketplace_screen.dart
+++ b/lib/screens/marketplace_screen.dart
@@ -66,13 +66,15 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
           return LayoutBuilder(
             builder: (context, constraints) {
               final crossAxisCount = constraints.maxWidth > 600 ? 3 : 2;
-              return GridView.builder(
-                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: crossAxisCount,
-                  childAspectRatio: 3 / 4,
-                ),
-                itemCount: products.length,
-                itemBuilder: (context, index) {
+              return FocusTraversalGroup(
+                policy: OrderedTraversalPolicy(),
+                child: GridView.builder(
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: crossAxisCount,
+                    childAspectRatio: 3 / 4,
+                  ),
+                  itemCount: products.length,
+                  itemBuilder: (context, index) {
                   final product = products[index];
                   try {
                     return ProductCard(
@@ -102,7 +104,8 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
                     }
                     return const SizedBox.shrink();
                   }
-                },
+                  },
+                ),
               );
             },
           );

--- a/lib/screens/shorts_screen.dart
+++ b/lib/screens/shorts_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import 'package:fouta_app/features/shorts/shorts_service.dart';
 import 'package:fouta_app/widgets/video_player_widget.dart';
+import 'package:fouta_app/theme/motion.dart';
 
 class ShortsScreen extends StatelessWidget {
   ShortsScreen({super.key, ShortsService? service})
@@ -12,6 +13,9 @@ class ShortsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
+    final duration = reduceMotion ? AppDurations.fast : AppDurations.normal;
+
     return StreamBuilder<List<Short>>(
       stream: _service.streamShorts(),
       builder: (context, snapshot) {
@@ -34,59 +38,58 @@ class ShortsScreen extends StatelessWidget {
           );
         }
         return Scaffold(
-          body: PageView.builder(
-            scrollDirection: Axis.vertical,
-            itemCount: items.length,
-            itemBuilder: (context, index) {
-              final short = items[index];
-              try {
-                final likeCount = short.likeIds.length;
-                return Stack(
-                  fit: StackFit.expand,
-                  children: [
-                    VideoPlayerWidget(
-                      videoUrl: short.url,
-                      videoId: short.id,
-                      aspectRatio: short.aspectRatio,
-                      areControlsVisible: false,
-                      shouldInitialize: true,
-                    ),
-                    Positioned(
-                      right: 16,
-                      bottom: 80,
-                      child: Column(
-                        children: [
-                          IconButton(
-                            icon: const Icon(Icons.favorite, color: Colors.white),
-                            onPressed: () {},
-                          ),
-                          Text('$likeCount',
-                              style: const TextStyle(color: Colors.white)),
-                          const SizedBox(height: 16),
-                          IconButton(
-                            icon: const Icon(Icons.comment, color: Colors.white),
-                            onPressed: () {},
-                          ),
-                          const SizedBox(height: 16),
-                          IconButton(
-                            icon: const Icon(Icons.share, color: Colors.white),
-                            onPressed: () {},
-                          ),
-                          const SizedBox(height: 16),
-                          IconButton(
-                            icon: const Icon(Icons.person_add, color: Colors.white),
-                            onPressed: () {},
-                          ),
-                        ],
+          body: AnimatedSwitcher(
+            duration: duration,
+            child: PageView.builder(
+              scrollDirection: Axis.vertical,
+              itemCount: items.length,
+              itemBuilder: (context, index) {
+                final short = items[index];
+                try {
+                  final likeCount = short.likeIds.length;
+                  Widget actionButton(IconData icon, VoidCallback onPressed) {
+                    final button = IconButton(
+                      icon: Icon(icon, color: Colors.white),
+                      onPressed: onPressed,
+                    );
+                    return reduceMotion ? button : animateOnTap(child: button, onTap: onPressed);
+                  }
+
+                  return Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      VideoPlayerWidget(
+                        videoUrl: short.url,
+                        videoId: short.id,
+                        aspectRatio: short.aspectRatio,
+                        areControlsVisible: false,
+                        shouldInitialize: true,
                       ),
-                    ),
-                  ],
-                );
-              } catch (e, st) {
-                debugPrint('Error rendering short ${short.id}: $e');
-                return const SizedBox.shrink();
-              }
-            },
+                      Positioned(
+                        right: 16,
+                        bottom: 80,
+                        child: Column(
+                          children: [
+                            actionButton(Icons.favorite, () {}),
+                            Text('$likeCount',
+                                style: const TextStyle(color: Colors.white)),
+                            const SizedBox(height: 16),
+                            actionButton(Icons.comment, () {}),
+                            const SizedBox(height: 16),
+                            actionButton(Icons.share, () {}),
+                            const SizedBox(height: 16),
+                            actionButton(Icons.person_add, () {}),
+                          ],
+                        ),
+                      ),
+                    ],
+                  );
+                } catch (e, st) {
+                  debugPrint('Error rendering short ${short.id}: $e');
+                  return const SizedBox.shrink();
+                }
+              },
+            ),
           ),
         );
       },

--- a/lib/widgets/post_card_widget.dart
+++ b/lib/widgets/post_card_widget.dart
@@ -23,6 +23,7 @@ import 'package:fouta_app/utils/overlays.dart';
 import 'package:fouta_app/features/moderation/moderation_service.dart';
 import 'package:fouta_app/utils/json_safety.dart';
 import '../services/post_service.dart';
+import 'package:fouta_app/theme/tokens.dart';
 import '../services/collections_service.dart';
 import '../features/stories/composer/create_story_screen.dart';
 import '../features/creation/editor/overlays/overlay_models.dart';
@@ -786,7 +787,7 @@ class _PostCardWidgetState extends State<PostCardWidget> {
       default:
         thumb = const SizedBox.shrink();
     }
-    return GestureDetector(
+    return InkWell(
       onTap: () {
         final items = attachments
             .whereType<Map<String, dynamic>>()
@@ -796,6 +797,7 @@ class _PostCardWidgetState extends State<PostCardWidget> {
         FullScreenMediaViewer.open(context, items, initialIndex: 0);
       },
       onDoubleTap: _likeOnDoubleTap,
+      focusColor: AppColors.primary.withOpacity(0.3),
       child: Stack(
         children: [
           thumb,
@@ -911,9 +913,10 @@ class _PostCardWidgetState extends State<PostCardWidget> {
     final String originMediaUrl = widget.post['originMediaUrl'] ?? '';
     final String originMediaType = widget.post['originMediaType'] ?? 'text';
     final String originAuthorDisplayName = widget.post['originAuthorDisplayName'] ?? 'Original Author';
-    
+
     final double? aspectRatio = widget.post['aspectRatio'] as double?;
     final List<dynamic> attachments = (widget.post['media'] ?? []) as List<dynamic>;
+    final double textScale = MediaQuery.textScaleFactorOf(context).clamp(1.0, 1.3);
 
     return VisibilityDetector(
       key: Key(widget.postId),
@@ -949,13 +952,14 @@ class _PostCardWidgetState extends State<PostCardWidget> {
                           fontStyle: FontStyle.italic,
                           fontSize: 13,
                         ),
+                        textScaleFactor: textScale,
                       ),
                     ],
                   ),
                 ),
               Row(
                 children: [
-                  GestureDetector(
+                  InkWell(
                     onTap: () {
                       Navigator.push(
                         context,
@@ -964,6 +968,7 @@ class _PostCardWidgetState extends State<PostCardWidget> {
                         ),
                       );
                     },
+                    focusColor: AppColors.primary.withOpacity(0.3),
                     child: CircleAvatar(
                       radius: 20,
                       backgroundImage: authorProfileImageUrl.isNotEmpty
@@ -978,7 +983,7 @@ class _PostCardWidgetState extends State<PostCardWidget> {
                     ),
                   ),
                   const SizedBox(width: 10),
-                  GestureDetector(
+                  InkWell(
                     onTap: () {
                       Navigator.push(
                         context,
@@ -987,6 +992,7 @@ class _PostCardWidgetState extends State<PostCardWidget> {
                         ),
                       );
                     },
+                    focusColor: AppColors.primary.withOpacity(0.3),
                     child: Text(
                       authorDisplayName,
                       style: TextStyle(
@@ -994,6 +1000,7 @@ class _PostCardWidgetState extends State<PostCardWidget> {
                         fontWeight: FontWeight.bold,
                         fontSize: 16,
                       ),
+                      textScaleFactor: textScale,
                     ),
                   ),
                   const Spacer(),
@@ -1121,6 +1128,8 @@ class _PostCardWidgetState extends State<PostCardWidget> {
                         Text(
                           originContent,
                           style: const TextStyle(fontSize: 15),
+                          textScaleFactor: textScale,
+                          softWrap: true,
                         ),
                     ],
                   ),
@@ -1129,6 +1138,8 @@ class _PostCardWidgetState extends State<PostCardWidget> {
                 Text(
                   widget.post['content'],
                   style: const TextStyle(fontSize: 16),
+                  textScaleFactor: textScale,
+                  softWrap: true,
                 ),
               // Display attachments if present.  Fall back to legacy single media for
               // backwards compatibility.
@@ -1163,8 +1174,9 @@ class _PostCardWidgetState extends State<PostCardWidget> {
                           onPressed: _toggleLike,
                         ),
                         const SizedBox(width: 4),
-                        GestureDetector(
+                        InkWell(
                           onTap: () => _showLikesDialog(context, asStringList(widget.post['likes'])),
+                          focusColor: AppColors.primary.withOpacity(0.3),
                           child: Text(
                             '$_likeCount',
                             style: TextStyle(
@@ -1176,12 +1188,13 @@ class _PostCardWidgetState extends State<PostCardWidget> {
                     ),
                   ),
                   Expanded(
-                    child: GestureDetector(
+                    child: InkWell(
                       onTap: () {
                         setState(() {
                           _showComments = !_showComments;
                         });
                       },
+                      focusColor: AppColors.primary.withOpacity(0.3),
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
@@ -1250,8 +1263,9 @@ class _PostCardWidgetState extends State<PostCardWidget> {
                     ),
                   ),
                   Expanded(
-                    child: GestureDetector(
+                    child: InkWell(
                       onTap: _toggleBookmark,
+                      focusColor: AppColors.primary.withOpacity(0.3),
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [

--- a/test/a11y_focus_test.dart
+++ b/test/a11y_focus_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/features/marketplace/marketplace_service.dart';
+import 'package:fouta_app/features/marketplace/product_card.dart';
+
+void main() {
+  testWidgets('focused product card shows focus highlight', (tester) async {
+    final product = Product(
+      id: '1',
+      sellerId: 'seller',
+      urls: const [],
+      title: 'Test',
+      category: 'c',
+      price: 1,
+      currency: 'USD',
+      favoriteUserIds: const [],
+    );
+
+    await tester.pumpWidget(MaterialApp(home: ProductCard(product: product)));
+
+    final inkFinder = find.descendant(
+      of: find.byType(ProductCard),
+      matching: find.byType(InkWell),
+    );
+    final element = tester.element(inkFinder);
+    final focusNode = Focus.of(element);
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
+
+    final material = Material.of(element);
+    expect(material.debugInkFeatures.any((f) => f is InkHighlight), isTrue);
+  });
+}

--- a/test/text_scale_clamp_test.dart
+++ b/test/text_scale_clamp_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/widgets/post_card_widget.dart';
+
+void main() {
+  testWidgets('text scale clamps to prevent overflow', (tester) async {
+    final post = {
+      'authorId': 'a',
+      'authorDisplayName': 'Author',
+      'content': 'lorem ipsum ' * 20,
+      'media': [],
+      'type': 'original',
+    };
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(textScaleFactor: 3.0),
+        child: MaterialApp(
+          home: PostCardWidget(
+            post: post,
+            postId: '1',
+            currentUser: null,
+            appId: 'app',
+            onMessage: (_) {},
+            isDataSaverOn: false,
+            isOnMobileData: false,
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- integrate focus-aware tappable elements and clamp text scaling to 1.3
- honor OS reduced-motion settings in Shorts and provide fast-motion fallback
- add focus traversal and semantics to marketplace cards

## Testing
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: 403 Forbidden)*
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_689c1c0eed10832b8aecae496ea9d1c1