### PR TITLE
docs: add app-origin trigger catalog and use case flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@
 - 2025-08-12 – UI Kit: tokens, motion, skeletons, progressive images.
 - 2025-08-12 – Integration Pass 1: ProgressiveImage + Skeletons + SafeBuilders + AnimatedLike/Bookmark in Feed, Shorts, Marketplace.
 - 2025-08-12 – docs(policy): allow nav bar and feed ranking edits with flags + measurement.
+- 2025-08-12 America/New_York – docs: add App-Origin Trigger Catalog, JSON rules, and UC flow rewrites.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [Admin Analytics](#admin-analytics)
 - [Notifications](#notifications)
 - [Stability Utilities](#stability-utilities)
+- [Use Cases & App-Origin Triggers](#use-cases--app-origin-triggers)
 
 - [Composer V2 (route /composeV2)](#composer-v2-route-composev2)
 
@@ -389,6 +390,11 @@ To re-run checks, go to Actions and select **Run workflow**.
 ## Environment Keys
 
 - `FCM_SERVER_KEY` – required by Cloud Functions `onNewInteraction` to send push notifications. If unset, the function logs a TODO and exits without sending.
+
+## Use Cases & App-Origin Triggers
+Documentation lives in [docs/use_cases](docs/use_cases) and [docs/triggers](docs/triggers).
+**Rule:** Every new screen/feature PR must cite a UC-ID and, if applicable, a Trigger `id`.
+All triggers must respect flags, frequency caps, and user controls.
 
 ## Change Log
 

--- a/docs/metrics/EVENTS_TAXONOMY.md
+++ b/docs/metrics/EVENTS_TAXONOMY.md
@@ -1,0 +1,33 @@
+# Events Taxonomy
+
+| Event | Use Case | Trigger | Recommended Props |
+| ----- | -------- | ------- | ----------------- |
+| `video_complete` | UC-01 | `next_up_rail` | `video_duration`, `position_in_session` |
+| `next_up_click` | UC-01 | `next_up_rail` | `recommended_id`, `position_in_session` |
+| `filter_chip_impression` | UC-01 | `keyword_filter_chips` | `tag`, `position_in_session` |
+| `filter_chip_click` | UC-01 | `keyword_filter_chips` | `tag`, `position_in_session` |
+| `friends_first_impression` | UC-02 | `friends_first_header` | `proximity_score` |
+| `friends_first_click` | UC-02 | `friends_first_header` | `friend_count` |
+| `story_view` | UC-02 | `story_inline_reply_chip` | `tag` |
+| `inline_reply_send` | UC-02 | `story_inline_reply_chip` | `share_channel` |
+| `template_suggestion_impression` | UC-03 | `template_suggestion_composer` | `tag` |
+| `template_use` | UC-03 | `template_suggestion_composer` | `template_id` |
+| `hint_impression` | UC-03 | `best_time_to_post_hint` | `position_in_session` |
+| `post_publish` | UC-03 | `best_time_to_post_hint` | `media_count` |
+| `suggestion_impression` | UC-04 | `query_suggestions_search` | `position` |
+| `suggestion_click` | UC-04 | `query_suggestions_search` | `query` |
+| `hashtag_panel_open` | UC-04 | `hashtag_overview_panel` | `tag` |
+| `hashtag_follow` | UC-04 | `hashtag_overview_panel` | `tag` |
+| `rules_view` | UC-05 | `group_rules_pinned` | `group_id` |
+| `rule_acknowledge` | UC-05 | `group_rules_pinned` | `group_id` |
+| `invite_sent` | UC-05 | `event_invite_via_dm` | `event_id`, `share_channel` |
+| `invite_accept` | UC-05 | `event_invite_via_dm` | `event_id` |
+| `alert_impression` | UC-06 | `saved_filter_alert_market` | `alert_id`, `tag` |
+| `listing_click` | UC-06 | `saved_filter_alert_market` | `listing_id`, `position_in_session` |
+| `price_drop_impression` | UC-06 | `price_drop_banner` | `listing_id`, `price_drop_pct` |
+| `price_drop_click` | UC-06 | `price_drop_banner` | `listing_id`, `price_drop_pct` |
+| `purchase_intent` | UC-06 | `price_drop_banner` | `amount`, `currency` |
+| `tune_feed_prompt` | UC-07 | `tune_your_feed_prompt` | `proximity_score` |
+| `tune_action` | UC-07 | `tune_your_feed_prompt` | `selected_topic` |
+| `muted_word_suggestion` | UC-07 | `muted_words_suggest` | `word` |
+| `muted_word_add` | UC-07 | `muted_words_suggest` | `word` |

--- a/docs/quality/BUGS_PRIORITY.md
+++ b/docs/quality/BUGS_PRIORITY.md
@@ -1,0 +1,7 @@
+# Bugs Priority
+
+| Priority | Issue | Root Cause Pattern | Status |
+| -------- | ----- | ----------------- | ------ |
+| P0 | Profile flicker | streams in build; multiple listeners | fixed/in progress |
+| P1 | _placeholder_ | _tbd_ | _tbd_ |
+| P2 | _placeholder_ | _tbd_ | _tbd_ |

--- a/docs/triggers/TRIGGER_CATALOG.md
+++ b/docs/triggers/TRIGGER_CATALOG.md
@@ -1,0 +1,183 @@
+# App-Origin Trigger Catalog
+
+## next_up_rail
+- **id:** `next_up_rail`
+- **name:** Next Up Rail
+- **surface:** Shorts / ForYou
+- **eligibility:** Completed shorts ratio ≥ 0.9, cooldown 30 minutes
+- **when_it_fires:** `video_complete`
+- **frequency_cap:** 3 per session, 8 per day
+- **priority:** 90
+- **flag_key:** `triggers.next_up.enabled`
+- **dismiss_behavior:** remember for session
+- **metrics:** `video_complete`, `next_up_click`, `session_length_delta`
+- **rollback_notes:** Disable flag and clear impression cache
+
+## keyword_filter_chips
+- **id:** `keyword_filter_chips`
+- **name:** Keyword Filter Chips
+- **surface:** ForYou
+- **eligibility:** Feed contains trending keywords
+- **when_it_fires:** `feed_load`
+- **frequency_cap:** 1 per session, 5 per day
+- **priority:** 70
+- **flag_key:** `triggers.keyword_filter_chips`
+- **dismiss_behavior:** hide for a day
+- **metrics:** `filter_chip_impression`, `filter_chip_click`
+- **rollback_notes:** Disable flag
+
+## friends_first_header
+- **id:** `friends_first_header`
+- **name:** Friends First Header
+- **surface:** Home Feed
+- **eligibility:** Feed has recent friend posts
+- **when_it_fires:** `feed_open`
+- **frequency_cap:** 2 per session, 6 per day
+- **priority:** 80
+- **flag_key:** `triggers.friends_first_header`
+- **dismiss_behavior:** remember for session
+- **metrics:** `friends_first_impression`, `friends_first_click`, `session_length_delta`
+- **rollback_notes:** Disable flag and remove header
+
+## story_inline_reply_chip
+- **id:** `story_inline_reply_chip`
+- **name:** Story Inline Reply Chip
+- **surface:** Stories
+- **eligibility:** Viewer can send DMs
+- **when_it_fires:** `story_view`
+- **frequency_cap:** 5 per session, 15 per day
+- **priority:** 60
+- **flag_key:** `triggers.story_inline_reply_chip`
+- **dismiss_behavior:** hide for session
+- **metrics:** `story_view`, `inline_reply_send`
+- **rollback_notes:** Disable flag
+
+## template_suggestion_composer
+- **id:** `template_suggestion_composer`
+- **name:** Template Suggestion in Composer
+- **surface:** Composer
+- **eligibility:** Draft has no media or text
+- **when_it_fires:** `composer_open`
+- **frequency_cap:** 2 per session, 4 per day
+- **priority:** 50
+- **flag_key:** `triggers.template_suggestion`
+- **dismiss_behavior:** remember per device
+- **metrics:** `template_suggestion_impression`, `template_use`
+- **rollback_notes:** Disable flag
+
+## best_time_to_post_hint
+- **id:** `best_time_to_post_hint`
+- **name:** Best Time to Post Hint
+- **surface:** Composer
+- **eligibility:** Account has audience data
+- **when_it_fires:** `composer_open`
+- **frequency_cap:** 1 per day
+- **priority:** 55
+- **flag_key:** `triggers.best_time_to_post`
+- **dismiss_behavior:** hide for 24h
+- **metrics:** `hint_impression`, `post_publish`
+- **rollback_notes:** Disable flag
+
+## hashtag_overview_panel
+- **id:** `hashtag_overview_panel`
+- **name:** Hashtag Overview Panel
+- **surface:** Search
+- **eligibility:** Query contains `#`
+- **when_it_fires:** `search_submit`
+- **frequency_cap:** 5 per day
+- **priority:** 65
+- **flag_key:** `triggers.hashtag_overview`
+- **dismiss_behavior:** remember for query
+- **metrics:** `hashtag_panel_open`, `hashtag_follow`
+- **rollback_notes:** Disable flag
+
+## query_suggestions_search
+- **id:** `query_suggestions_search`
+- **name:** Query Suggestions in Search
+- **surface:** Search
+- **eligibility:** Empty search box focus
+- **when_it_fires:** `search_focus`
+- **frequency_cap:** unlimited per session
+- **priority:** 40
+- **flag_key:** `triggers.query_suggestions`
+- **dismiss_behavior:** hide for session
+- **metrics:** `suggestion_impression`, `suggestion_click`
+- **rollback_notes:** Disable flag
+
+## group_rules_pinned
+- **id:** `group_rules_pinned`
+- **name:** Group Rules Pinned
+- **surface:** Groups
+- **eligibility:** User is group member
+- **when_it_fires:** `group_open`
+- **frequency_cap:** 1 per group per day
+- **priority:** 75
+- **flag_key:** `triggers.group_rules`
+- **dismiss_behavior:** remember acknowledgment
+- **metrics:** `rules_view`, `rule_acknowledge`
+- **rollback_notes:** Disable flag
+
+## event_invite_via_dm
+- **id:** `event_invite_via_dm`
+- **name:** Event Invite via DM
+- **surface:** Events
+- **eligibility:** User RSVP'd "going"
+- **when_it_fires:** `rsvp_success`
+- **frequency_cap:** 3 per event
+- **priority:** 70
+- **flag_key:** `triggers.event_invite_dm`
+- **dismiss_behavior:** remember per event
+- **metrics:** `invite_sent`, `invite_accept`
+- **rollback_notes:** Disable flag
+
+## saved_filter_alert_market
+- **id:** `saved_filter_alert_market`
+- **name:** Saved Filter Alert in Marketplace
+- **surface:** Marketplace
+- **eligibility:** User has saved search filter
+- **when_it_fires:** `price_match`
+- **frequency_cap:** 5 per day
+- **priority:** 60
+- **flag_key:** `triggers.saved_filter_alert`
+- **dismiss_behavior:** hide for 24h
+- **metrics:** `alert_impression`, `listing_click`
+- **rollback_notes:** Disable flag
+
+## price_drop_banner
+- **id:** `price_drop_banner`
+- **name:** Price Drop Banner
+- **surface:** Marketplace
+- **eligibility:** Saved item drops price ≥10%
+- **when_it_fires:** `price_drop_detected`
+- **frequency_cap:** 2 per item per day
+- **priority:** 85
+- **flag_key:** `triggers.price_drop`
+- **dismiss_behavior:** remember per item
+- **metrics:** `price_drop_impression`, `price_drop_click`, `purchase_intent`
+- **rollback_notes:** Disable flag
+
+## tune_your_feed_prompt
+- **id:** `tune_your_feed_prompt`
+- **name:** Tune Your Feed Prompt
+- **surface:** Feed Settings
+- **eligibility:** User reported irrelevant content
+- **when_it_fires:** `settings_open`
+- **frequency_cap:** 1 per session
+- **priority:** 50
+- **flag_key:** `triggers.tune_feed`
+- **dismiss_behavior:** hide for session
+- **metrics:** `tune_feed_prompt`, `tune_action`
+- **rollback_notes:** Disable flag
+
+## muted_words_suggest
+- **id:** `muted_words_suggest`
+- **name:** Muted Words Suggestion
+- **surface:** Safety Settings
+- **eligibility:** Recent negative interactions
+- **when_it_fires:** `settings_open`
+- **frequency_cap:** 1 per day
+- **priority:** 45
+- **flag_key:** `triggers.muted_words_suggest`
+- **dismiss_behavior:** remember per word
+- **metrics:** `muted_word_suggestion`, `muted_word_add`
+- **rollback_notes:** Disable flag

--- a/docs/triggers/TRIGGER_RULES.json
+++ b/docs/triggers/TRIGGER_RULES.json
@@ -1,0 +1,156 @@
+[
+  {
+    "id": "next_up_rail",
+    "surface": "shorts",
+    "eligibility": {"completed_ratio_gte": 0.9, "cooldown_minutes": 30},
+    "fires": {"on": "video_complete"},
+    "frequency_cap": {"per_session": 3, "per_day": 8},
+    "flag": "triggers.next_up.enabled",
+    "priority": 90,
+    "dismiss": "remember_for_session",
+    "metrics": ["video_complete", "next_up_click", "session_length_delta"]
+  },
+  {
+    "id": "keyword_filter_chips",
+    "surface": "for_you",
+    "eligibility": {"has_trending_keywords": true},
+    "fires": {"on": "feed_load"},
+    "frequency_cap": {"per_session": 1, "per_day": 5},
+    "flag": "triggers.keyword_filter_chips",
+    "priority": 70,
+    "dismiss": "hide_for_day",
+    "metrics": ["filter_chip_impression", "filter_chip_click"]
+  },
+  {
+    "id": "friends_first_header",
+    "surface": "home_feed",
+    "eligibility": {"friend_posts_gt": 0},
+    "fires": {"on": "feed_open"},
+    "frequency_cap": {"per_session": 2, "per_day": 6},
+    "flag": "triggers.friends_first_header",
+    "priority": 80,
+    "dismiss": "remember_for_session",
+    "metrics": ["friends_first_impression", "friends_first_click", "session_length_delta"]
+  },
+  {
+    "id": "story_inline_reply_chip",
+    "surface": "stories",
+    "eligibility": {"viewer_can_dm": true},
+    "fires": {"on": "story_view"},
+    "frequency_cap": {"per_session": 5, "per_day": 15},
+    "flag": "triggers.story_inline_reply_chip",
+    "priority": 60,
+    "dismiss": "hide_for_session",
+    "metrics": ["story_view", "inline_reply_send"]
+  },
+  {
+    "id": "template_suggestion_composer",
+    "surface": "composer",
+    "eligibility": {"draft_empty": true},
+    "fires": {"on": "composer_open"},
+    "frequency_cap": {"per_session": 2, "per_day": 4},
+    "flag": "triggers.template_suggestion",
+    "priority": 50,
+    "dismiss": "remember_per_device",
+    "metrics": ["template_suggestion_impression", "template_use"]
+  },
+  {
+    "id": "best_time_to_post_hint",
+    "surface": "composer",
+    "eligibility": {"has_audience_data": true},
+    "fires": {"on": "composer_open"},
+    "frequency_cap": {"per_day": 1},
+    "flag": "triggers.best_time_to_post",
+    "priority": 55,
+    "dismiss": "hide_for_day",
+    "metrics": ["hint_impression", "post_publish"]
+  },
+  {
+    "id": "hashtag_overview_panel",
+    "surface": "search",
+    "eligibility": {"query_hashtag": true},
+    "fires": {"on": "search_submit"},
+    "frequency_cap": {"per_day": 5},
+    "flag": "triggers.hashtag_overview",
+    "priority": 65,
+    "dismiss": "remember_per_query",
+    "metrics": ["hashtag_panel_open", "hashtag_follow"]
+  },
+  {
+    "id": "query_suggestions_search",
+    "surface": "search",
+    "eligibility": {"query_empty": true},
+    "fires": {"on": "search_focus"},
+    "frequency_cap": {"per_session": -1},
+    "flag": "triggers.query_suggestions",
+    "priority": 40,
+    "dismiss": "hide_for_session",
+    "metrics": ["suggestion_impression", "suggestion_click"]
+  },
+  {
+    "id": "group_rules_pinned",
+    "surface": "groups",
+    "eligibility": {"is_member": true},
+    "fires": {"on": "group_open"},
+    "frequency_cap": {"per_group_per_day": 1},
+    "flag": "triggers.group_rules",
+    "priority": 75,
+    "dismiss": "remember_acknowledgment",
+    "metrics": ["rules_view", "rule_acknowledge"]
+  },
+  {
+    "id": "event_invite_via_dm",
+    "surface": "events",
+    "eligibility": {"rsvp_positive": true},
+    "fires": {"on": "rsvp_success"},
+    "frequency_cap": {"per_event": 3},
+    "flag": "triggers.event_invite_dm",
+    "priority": 70,
+    "dismiss": "remember_per_event",
+    "metrics": ["invite_sent", "invite_accept"]
+  },
+  {
+    "id": "saved_filter_alert_market",
+    "surface": "marketplace",
+    "eligibility": {"has_saved_filter": true},
+    "fires": {"on": "price_match"},
+    "frequency_cap": {"per_day": 5},
+    "flag": "triggers.saved_filter_alert",
+    "priority": 60,
+    "dismiss": "hide_for_day",
+    "metrics": ["alert_impression", "listing_click"]
+  },
+  {
+    "id": "price_drop_banner",
+    "surface": "marketplace",
+    "eligibility": {"price_drop_pct_gte": 10},
+    "fires": {"on": "price_drop_detected"},
+    "frequency_cap": {"per_item_per_day": 2},
+    "flag": "triggers.price_drop",
+    "priority": 85,
+    "dismiss": "remember_per_item",
+    "metrics": ["price_drop_impression", "price_drop_click", "purchase_intent"]
+  },
+  {
+    "id": "tune_your_feed_prompt",
+    "surface": "feed_settings",
+    "eligibility": {"reported_irrelevant": true},
+    "fires": {"on": "settings_open"},
+    "frequency_cap": {"per_session": 1},
+    "flag": "triggers.tune_feed",
+    "priority": 50,
+    "dismiss": "hide_for_session",
+    "metrics": ["tune_feed_prompt", "tune_action"]
+  },
+  {
+    "id": "muted_words_suggest",
+    "surface": "safety_settings",
+    "eligibility": {"recent_negative_interactions": true},
+    "fires": {"on": "settings_open"},
+    "frequency_cap": {"per_day": 1},
+    "flag": "triggers.muted_words_suggest",
+    "priority": 45,
+    "dismiss": "remember_per_word",
+    "metrics": ["muted_word_suggestion", "muted_word_add"]
+  }
+]

--- a/docs/use_cases/USE_CASES_OVERVIEW.md
+++ b/docs/use_cases/USE_CASES_OVERVIEW.md
@@ -1,0 +1,16 @@
+# Use Cases Overview
+
+**Strategy:** Maximum engagement via app-origin triggers; rank for watch time, shares/DMs, follows-after-view; 7-day decay.
+
+## Flows
+- [UC-01 Quick Entertainment](flows/UC-01-quick-entertainment.md)
+- [UC-02 Keep Up with People](flows/UC-02-keep-up-with-people.md)
+- [UC-03 Express Identity](flows/UC-03-express-identity.md)
+- [UC-04 Discover and Learn](flows/UC-04-discover-and-learn.md)
+- [UC-05 Belong and Coordinate](flows/UC-05-belong-and-coordinate.md)
+- [UC-06 Support and Transact](flows/UC-06-support-and-transact.md)
+- [UC-07 Safety and Control](flows/UC-07-safety-and-control.md)
+
+## Reference
+- [Trigger Catalog](../triggers/TRIGGER_CATALOG.md)
+- [Trigger Rules](../triggers/TRIGGER_RULES.json)

--- a/docs/use_cases/flows/UC-01-quick-entertainment.md
+++ b/docs/use_cases/flows/UC-01-quick-entertainment.md
@@ -1,0 +1,24 @@
+# UC-01 Quick Entertainment
+
+**Origin → App Trigger → Action → Outcome → Signals**
+
+Feed scroll → `next_up_rail` → tap recommended short → next video plays → `video_complete`, `next_up_click`, `session_length_delta`
+
+## 5Ws
+| Who | What | When | Where | Why |
+| --- | --- | --- | --- | --- |
+| Casual scrollers | Watch short videos | Break moments | Shorts feed | Fast fun |
+
+## Guardrails
+- Flag `triggers.next_up.enabled`
+- Cap 3/session, 8/day
+- Dismiss remembers for session
+
+## Instrumentation checklist
+- `video_complete` (video_duration, position_in_session)
+- `next_up_click` (recommended_id)
+- `session_length_delta` (seconds)
+
+## Rollout & rollback
+- Ramp: 5% → 50% → 100%
+- Rollback: disable flag and clear impression cache

--- a/docs/use_cases/flows/UC-02-keep-up-with-people.md
+++ b/docs/use_cases/flows/UC-02-keep-up-with-people.md
@@ -1,0 +1,25 @@
+# UC-02 Keep Up with People
+
+**Origin → App Trigger → Action → Outcome → Signals**
+
+Feed open → `friends_first_header` → tap friend cluster → view story and reply → `friends_first_click`, `story_view`, `inline_reply_send`
+
+## 5Ws
+| Who | What | When | Where | Why |
+| --- | --- | --- | --- | --- |
+| Connected users | Check friends | Daily | Home feed & stories | Stay updated |
+
+## Guardrails
+- Flag `triggers.friends_first_header`
+- Cap 2/session, 6/day
+- Dismiss hides header for session
+
+## Instrumentation checklist
+- `friends_first_impression` (proximity_score)
+- `friends_first_click` (friend_count)
+- `story_view` (tag)
+- `inline_reply_send` (share_channel)
+
+## Rollout & rollback
+- Ramp by region 10% → 50% → 100%
+- Rollback: disable flag and remove cached header

--- a/docs/use_cases/flows/UC-03-express-identity.md
+++ b/docs/use_cases/flows/UC-03-express-identity.md
@@ -1,0 +1,24 @@
+# UC-03 Express Identity
+
+**Origin → App Trigger → Action → Outcome → Signals**
+
+Composer open → `template_suggestion_composer` → pick template and craft post → publish personal content → `template_use`, `post_publish`
+
+## 5Ws
+| Who | What | When | Where | Why |
+| --- | --- | --- | --- | --- |
+| Creators | Share perspective | Drafting time | Composer | Showcase self |
+
+## Guardrails
+- Flag `triggers.template_suggestion`
+- Cap 2/session, 4/day
+- User can ignore suggestion
+
+## Instrumentation checklist
+- `template_suggestion_impression` (tag)
+- `template_use` (template_id)
+- `post_publish` (media_count)
+
+## Rollout & rollback
+- Ramp: 5% → 25% → 100%
+- Rollback: disable flag and purge templates

--- a/docs/use_cases/flows/UC-04-discover-and-learn.md
+++ b/docs/use_cases/flows/UC-04-discover-and-learn.md
@@ -1,0 +1,25 @@
+# UC-04 Discover and Learn
+
+**Origin → App Trigger → Action → Outcome → Signals**
+
+Search focus → `query_suggestions_search` → tap suggestion → hashtag panel opens → `suggestion_click`, `hashtag_panel_open`, `hashtag_follow`
+
+## 5Ws
+| Who | What | When | Where | Why |
+| --- | --- | --- | --- | --- |
+| Curious users | Explore topics | When searching | Search surface | Learn new things |
+
+## Guardrails
+- Flag `triggers.query_suggestions`
+- Unlimited per session
+- Users can dismiss suggestions
+
+## Instrumentation checklist
+- `suggestion_impression` (position)
+- `suggestion_click` (query)
+- `hashtag_panel_open` (tag)
+- `hashtag_follow` (tag)
+
+## Rollout & rollback
+- Ramp: 10% → 50% → 100%
+- Rollback: disable flag and clear suggestion cache

--- a/docs/use_cases/flows/UC-05-belong-and-coordinate.md
+++ b/docs/use_cases/flows/UC-05-belong-and-coordinate.md
@@ -1,0 +1,24 @@
+# UC-05 Belong and Coordinate
+
+**Origin → App Trigger → Action → Outcome → Signals**
+
+Group open → `group_rules_pinned` → acknowledge rules → invite friend to event via DM → `rules_view`, `rule_acknowledge`, `invite_sent`
+
+## 5Ws
+| Who | What | When | Where | Why |
+| --- | --- | --- | --- | --- |
+| Community members | Align on norms | Joining groups | Group page | Coordinate activity |
+
+## Guardrails
+- Flag `triggers.group_rules`
+- 1 per group/day
+- Dismiss after acknowledge
+
+## Instrumentation checklist
+- `rules_view` (group_id)
+- `rule_acknowledge` (group_id)
+- `invite_sent` (event_id, share_channel)
+
+## Rollout & rollback
+- Ramp: 5% → 25% → 100%
+- Rollback: disable flag and remove pinned panel

--- a/docs/use_cases/flows/UC-06-support-and-transact.md
+++ b/docs/use_cases/flows/UC-06-support-and-transact.md
@@ -1,0 +1,24 @@
+# UC-06 Support and Transact
+
+**Origin → App Trigger → Action → Outcome → Signals**
+
+Price match → `saved_filter_alert_market` → open listing → complete purchase intent → `alert_impression`, `listing_click`, `purchase_intent`
+
+## 5Ws
+| Who | What | When | Where | Why |
+| --- | --- | --- | --- | --- |
+| Shoppers | Buy items | Price drops | Marketplace alerts | Support creators |
+
+## Guardrails
+- Flag `triggers.saved_filter_alert`
+- Cap 5/day
+- User can mute alerts
+
+## Instrumentation checklist
+- `alert_impression` (alert_id, tag)
+- `listing_click` (listing_id, position_in_session)
+- `purchase_intent` (amount, currency)
+
+## Rollout & rollback
+- Ramp: 10% → 50% → 100%
+- Rollback: disable flag and clear saved alerts

--- a/docs/use_cases/flows/UC-07-safety-and-control.md
+++ b/docs/use_cases/flows/UC-07-safety-and-control.md
@@ -1,0 +1,25 @@
+# UC-07 Safety and Control
+
+**Origin → App Trigger → Action → Outcome → Signals**
+
+Settings open → `tune_your_feed_prompt` → adjust preferences → add muted words → `tune_action`, `muted_word_add`
+
+## 5Ws
+| Who | What | When | Where | Why |
+| --- | --- | --- | --- | --- |
+| Concerned users | Curate feed | After seeing irrelevant content | Settings | Safer experience |
+
+## Guardrails
+- Flag `triggers.tune_feed`
+- 1 per session
+- Opt-out in settings
+
+## Instrumentation checklist
+- `tune_feed_prompt` (proximity_score)
+- `tune_action` (selected_topic)
+- `muted_word_suggestion` (word)
+- `muted_word_add` (word)
+
+## Rollout & rollback
+- Ramp: 5% → 25% → 100%
+- Rollback: disable flag and reset prompt state


### PR DESCRIPTION
## Summary
- document 14 app-origin triggers and rules
- rewrite 7 use-case flows to start from app triggers
- add events taxonomy and bugs priority

## Testing
- `jq . docs/triggers/TRIGGER_RULES.json`
- `npx markdownlint docs/triggers/TRIGGER_CATALOG.md docs/use_cases/USE_CASES_OVERVIEW.md docs/use_cases/flows/UC-01-quick-entertainment.md docs/use_cases/flows/UC-02-keep-up-with-people.md docs/use_cases/flows/UC-03-express-identity.md docs/use_cases/flows/UC-04-discover-and-learn.md docs/use_cases/flows/UC-05-belong-and-coordinate.md docs/use_cases/flows/UC-06-support-and-transact.md docs/use_cases/flows/UC-07-safety-and-control.md docs/metrics/EVENTS_TAXONOMY.md docs/quality/BUGS_PRIORITY.md README.md` (fails: 403 Forbidden)
- `flutter pub get` (fails: command not found)
- `flutter analyze` (fails: command not found)
- `dart format --output=none --set-exit-if-changed .` (fails: command not found)
- `flutter test --no-pub --coverage` (fails: command not found)
- `npm ci` (fails: lockfile mismatch)
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_689c2ad5ead4832b9220a888c9392d89