### PR TITLE
fix(ux): shorts structure, profile flicker, events const, trending chips state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
-
-
+- 2025-08-12 – Fix Shorts widget structure; remove const misuse in Events; stabilize Profile; tighten trending tags state.
 - 2025-08-12 – fix(profile): eliminate flicker by caching streams, distinct setState, and gapless image rendering. (Committed on fallback branch `work` due to branch creation restrictions.)
 - 2025-08-12 – Integration Pass 3: focus visuals, textScale guardrails, reduced-motion fallbacks. (Committed on fallback branch `work` due to branch creation restrictions.)
 - 2025-08-12 – Integration Pass 2: Hero images, FoutaTransitions in Post/Shorts detail flows. (Committed on fallback branch `work` due to branch creation restrictions.)

--- a/lib/screens/event_detail_screen.dart
+++ b/lib/screens/event_detail_screen.dart
@@ -9,14 +9,13 @@ class EventDetailScreen extends StatefulWidget {
   final String currentUserId;
 
   EventDetailScreen({
-    Key? key,
+    super.key,
     required this.event,
     EventsService? service,
     String? currentUserId,
   })  : service = service ?? EventsService(),
         currentUserId =
-            currentUserId ?? FirebaseAuth.instance.currentUser?.uid ?? '',
-        super(key: key);
+            currentUserId ?? FirebaseAuth.instance.currentUser?.uid ?? '';
 
   @override
   State<EventDetailScreen> createState() => _EventDetailScreenState();

--- a/lib/screens/events_list_screen.dart
+++ b/lib/screens/events_list_screen.dart
@@ -8,14 +8,10 @@ class EventsListScreen extends StatefulWidget {
   final EventsService service;
   final String currentUserId;
 
-  EventsListScreen({
-    Key? key,
-    EventsService? service,
-    String? currentUserId,
-  })  : service = service ?? EventsService(),
+  EventsListScreen({super.key, EventsService? service, String? currentUserId})
+      : service = service ?? EventsService(),
         currentUserId =
-            currentUserId ?? FirebaseAuth.instance.currentUser?.uid ?? '',
-        super(key: key);
+            currentUserId ?? FirebaseAuth.instance.currentUser?.uid ?? '';
 
   @override
   State<EventsListScreen> createState() => _EventsListScreenState();

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -577,15 +577,20 @@ class _FeedTabState extends State<FeedTab> with AutomaticKeepAliveClientMixin {
   List<Story> _stories = [];
 
   // Trending chips state
-  List<String> _trendingTags = const [];
+  List<String> _trendingTags = const <String>[];
   String? _selectedTag;
 
   static const List<String> _fallbackTags = ['news', 'tech', 'sports'];
 
   void _onTagSelected(String? tag) {
+    if (_selectedTag == tag) return;
     setState(() {
       _selectedTag = tag;
+      _posts = [];
+      _lastDocument = null;
+      _hasMore = true;
     });
+    _fetchFirstPosts();
   }
 
 
@@ -825,6 +830,9 @@ class _FeedTabState extends State<FeedTab> with AutomaticKeepAliveClientMixin {
         .collection(FirestorePaths.posts())
         .orderBy('timestamp', descending: true)
         .limit(_postsLimit);
+    if (_selectedTag != null) {
+      query = query.where('meta.hashtags', arrayContains: _selectedTag);
+    }
 
     final querySnapshot = await query.get();
 
@@ -850,6 +858,9 @@ class _FeedTabState extends State<FeedTab> with AutomaticKeepAliveClientMixin {
         .orderBy('timestamp', descending: true)
         .startAfterDocument(_lastDocument!)
         .limit(_postsLimit);
+    if (_selectedTag != null) {
+      query = query.where('meta.hashtags', arrayContains: _selectedTag);
+    }
 
     final querySnapshot = await query.get();
 

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -29,6 +29,7 @@ import 'package:fouta_app/widgets/safe_stream_builder.dart';
 import 'package:fouta_app/widgets/safe_future_builder.dart';
 import 'package:fouta_app/utils/async_guard.dart';
 import 'package:fouta_app/screens/profile/profile_header.dart';
+import 'package:fouta_app/widgets/progressive_image.dart';
 
 class ProfileScreen extends StatefulWidget {
   final String userId;
@@ -789,14 +790,10 @@ class _MediaGridTile extends StatelessWidget {
         child: Stack(
           fit: StackFit.expand,
           children: [
-            CachedNetworkImage(
+            ProgressiveImage(
               imageUrl: mediaUrl,
+              thumbUrl: post['thumbUrl'] ?? mediaUrl,
               fit: BoxFit.cover,
-              progressIndicatorBuilder: (context, url, progress) => Container(
-                color: Theme.of(context).colorScheme.surfaceVariant,
-                child: const Center(child: CircularProgressIndicator()),
-              ),
-              errorWidget: (context, url, error) => const Icon(Icons.error),
             ),
             if (mediaType == 'video')
               Positioned(

--- a/test/new_screens_test.dart
+++ b/test/new_screens_test.dart
@@ -3,11 +3,21 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fouta_app/screens/shorts_screen.dart';
 import 'package:fouta_app/screens/marketplace_screen.dart';
 import 'package:fouta_app/screens/ar_camera_screen.dart';
+import 'package:fouta_app/features/shorts/shorts_service.dart';
+
+class _FakeShortsService extends ShortsService {
+  _FakeShortsService() : super();
+  @override
+  Stream<List<Short>> streamShorts() => Stream.value(<Short>[]);
+}
 
 void main() {
-  testWidgets('Shorts screen shows placeholder', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: ShortsScreen()));
-    expect(find.text('Short-form videos coming soon.'), findsOneWidget);
+  testWidgets('Shorts screen shows empty state', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(home: ShortsScreen(service: _FakeShortsService())),
+    );
+    await tester.pump();
+    expect(find.text('No shorts yet'), findsOneWidget);
   });
 
   testWidgets('Marketplace screen shows placeholder', (tester) async {

--- a/test/shorts_render_error_test.dart
+++ b/test/shorts_render_error_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/screens/shorts_screen.dart';
+import 'package:fouta_app/features/shorts/shorts_service.dart';
+
+class _ErrorShortsService extends ShortsService {
+  _ErrorShortsService() : super();
+  @override
+  Stream<List<Short>> streamShorts() {
+    return Stream.value([
+      Short(
+        id: '1',
+        authorId: 'a',
+        url: '',
+        aspectRatio: 0,
+        duration: null,
+        likeIds: const [],
+      ),
+    ]);
+  }
+}
+
+void main() {
+  testWidgets('renders failure tile when builder throws', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(home: ShortsScreen(service: _ErrorShortsService())),
+    );
+    await tester.pump();
+    expect(find.text('failed to render'), findsOneWidget);
+  });
+}

--- a/test/shorts_screen_test.dart
+++ b/test/shorts_screen_test.dart
@@ -18,7 +18,7 @@ class _FakeShortsService extends ShortsService {
 void main() {
   testWidgets('Shorts screen scrolls vertically', (tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: ShortsScreen(service: _FakeShortsService()),
       ),
     );


### PR DESCRIPTION
## Summary
- convert Shorts screen into a proper stateful widget, manage controllers, and surface a "failed to render" tile with reporting
- stabilize profile media grid by switching to ProgressiveImage
- refresh feed when trending tag changes and filter queries; remove stale const constructors from events

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci && npm test --if-present` *(fails: 403 Forbidden retrieving package)*

------
https://chatgpt.com/codex/tasks/task_e_689c2dc8f990832baf44edf4d6b9cb47