### PR TITLE
fix(ui): make KeywordFilterChips.selectedTag optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,4 @@
 - 2025-08-12 America/New_York – docs: add App-Origin Trigger Catalog, JSON rules, and UC flow rewrites.
 
 - 2025-08-12 – feat(triggers,ranking): add Trigger Orchestrator (v1) + UI widgets + Discovery Ranking V2 skeleton; no integration yet.
+- 2025-08-12 America/New_York – fix(ui): make KeywordFilterChips.selectedTag optional (defaults to All) to resolve build error in home_screen.dart.

--- a/lib/widgets/triggers/keyword_filter_chips.dart
+++ b/lib/widgets/triggers/keyword_filter_chips.dart
@@ -3,15 +3,15 @@ import 'package:flutter/material.dart';
 
 class KeywordFilterChips extends StatelessWidget {
   final List<String> tags;
-  final String? selectedTag;
+  final String? selectedTag; // optional; null means "All"
   final ValueChanged<String?> onSelected;
   final EdgeInsetsGeometry padding;
 
   const KeywordFilterChips({
     super.key,
     List<String>? tags,
-    List<String>? keywords, // alias for legacy call sites
-    required this.selectedTag,
+    List<String>? keywords, // legacy alias
+    this.selectedTag, // <-- now optional (default null)
     required this.onSelected,
     this.padding = const EdgeInsets.symmetric(horizontal: 12.0, vertical: 6.0),
   }) : tags = tags ?? keywords ?? const <String>[];
@@ -31,14 +31,16 @@ class KeywordFilterChips extends StatelessWidget {
               onSelected: (_) => onSelected(null),
             ),
             const SizedBox(width: 8),
-            ...tags.map((t) => Padding(
-                  padding: const EdgeInsets.only(right: 8),
-                  child: FilterChip(
-                    label: Text('#$t'),
-                    selected: selectedTag == t,
-                    onSelected: (_) => onSelected(t),
-                  ),
-                )),
+            ...tags.map(
+              (t) => Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: FilterChip(
+                  label: Text('#$t'),
+                  selected: selectedTag == t,
+                  onSelected: (_) => onSelected(t),
+                ),
+              ),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- allow KeywordFilterChips.selectedTag to be null so "All" state doesn't require explicit prop

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci && npm test --if-present` *(fails: missing lock file deps)*
- `flutter run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c4006cf28832bb379b44e5cbe7172