### PR TITLE
docs: refine AI policy for codex prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,12 +18,16 @@
 - Cite changed files and test logs.
 
 ## Repo policy
-- **File output:** Full file replacements (no ellipses).
+- **Outputs:** The AI must provide detailed prompts for the codex agent specifying which files to edit, what content to add or modify, and why. Do not generate partial snippets without context. Each prompt must include the relevant spec ID, file paths, and a rollback plan.
 - **Branches:** Agents may create/switch branches. If blocked, commit on `dev` and note fallback.
 - **Dependencies:** Allowed when a DEP record is added and CI passes (see DEP policy).
+- **Spec-driven:** No changes may be made without an approved one-page feature spec in `/docs/specs/<ticket>_v<version>.md`. Each spec must include context, requirements, data contracts, acceptance criteria, flags, metrics, risks, test plan, and rollback steps.
+- **Budgets:** CI must fail if p95 latency exceeds 800 ms or if storage/egress grows by more than 20% month-over-month.
+- Branches and dependency rules remain unchanged.
 - **Auth screens:** No bottom nav on Login/Signup.
 
 ## Navigation & Feed policy (updated)
+- Codex prompts must document the feature flag, metrics, and rollback plan.
 - **Nav bar changes are allowed** when:
   1) Changes are behind a **feature flag** (e.g., `remoteConfig.nav_variant = 'A'|'B'` or Firestore config).
   2) A short measurement plan is included (click‑through, dwell time, nav errors).

--- a/README.md
+++ b/README.md
@@ -239,11 +239,13 @@ For help getting started with Flutter development, view the [online documentatio
 ### AI Collaboration
 - AI agents must document their work, including context, decisions, and timestamps.
 - Append updates to existing documentation and logs rather than overwriting previous entries.
+- The AI you interact with will consider the perspectives of PM, Developer, Tester, Designer, DevOps, Data, Security, Accessibility, and Product in every response. It will call out implementation details, testing requirements, UI/a11y considerations, deployment impacts, data migrations, security/privacy concerns, and policy compliance for each request.
 
 ## AI Collaboration & Policy
-- Agents may create or switch branches other than the protected `main` branch.
-- Agents may add runtime and dev dependencies when a DEP record is created and all CI checks pass.
-- See [AGENTS.md](AGENTS.md) and [DEPENDENCIES.md](DEPENDENCIES.md) for full details.
+- AI-generated prompts must target a feature branch (`feat/*` or `fix/*`). Do not commit directly to `main`.
+- AI-generated prompts may add runtime and dev dependencies only when accompanied by a DEP record and after all CI checks pass.
+- All AI outputs must be structured prompts for codex rather than full file replacements. Prompts must reference the relevant spec ID and include context, file paths, and a rollback plan.
+- See [AGENTS.md](AGENTS.md) for the complete policy and [DEPENDENCIES.md](DEPENDENCIES.md) for dependency details.
 
 ## Development Notes
 


### PR DESCRIPTION
## Summary
- document codex prompt workflow and spec-driven gates in AGENTS
- clarify branching, dependency, and multi-role guidelines in README

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: package.json and lockfile out of sync)*
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_689d735e5690832b82496dac56dd7703