### PR TITLE
feat: add Crashlytics error reporting flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,8 +490,10 @@ In-app notifications live at `artifacts/$APP_ID/public/data/notifications/{uid}/
 ## Stability Utilities
 Reusable helpers ensure widgets and async code fail gracefully.
 
-### Error Reporting Stub
-Errors surface through `ErrorReporter.report` for centralized capture.
+### Error Reporting
+Errors surface through `ErrorReporter.report` for centralized capture. See
+[`docs/ops/error-reporting.md`](docs/ops/error-reporting.md) for the
+`CRASHLYTICS_ENABLED` flag and rollback steps.
 
 ## Composer V2 (route /composeV2)
 Experimental composer supporting drafts and scheduled posts.

--- a/docs/dependencies/DEP-20250814-firebase-crashlytics.md
+++ b/docs/dependencies/DEP-20250814-firebase-crashlytics.md
@@ -1,0 +1,31 @@
+# DEP: firebase_crashlytics
+Date: 2025-08-14
+Author: ChatGPT
+Status: Adopted
+
+## Purpose
+Provide Crashlytics-based runtime error reporting controlled by a flag.
+
+## Package
+- Name: firebase_crashlytics
+- Link: https://pub.dev/packages/firebase_crashlytics
+- License: BSD-3-Clause
+
+## Alternatives considered
+- Sentry — broader features but heavier setup.
+- Custom logging — no external visibility or aggregation.
+
+## Platform impact
+- Android: No additional manifest changes.
+- iOS: No new entitlements; Pod install handled by FlutterFire.
+- Web: No web-specific changes.
+
+## Data, privacy & security
+Sends error strings and stack traces to Firebase; avoid PII in messages.
+
+## Test & rollout plan
+Unit tests verify Crashlytics invocation. Roll out behind
+`CRASHLYTICS_ENABLED` flag.
+
+## Removal plan
+Remove dependency and flag usage, run `flutter pub get`, and delete this DEP.

--- a/docs/ops/error-reporting.md
+++ b/docs/ops/error-reporting.md
@@ -1,0 +1,15 @@
+# Error Reporting
+
+`CRASHLYTICS_ENABLED` controls forwarding of runtime errors to
+`FirebaseCrashlytics`. The flag defaults to `false` to avoid sending reports
+from local or test environments.
+
+## Usage
+1. Set `AppFlags.crashlyticsEnabled = true` at startup for production builds.
+2. Ensure errors are reported through `ErrorReporter.report`.
+3. Crashlytics receives only error strings and stack traces; avoid attaching
+   sensitive user data.
+
+## Rollback
+- Disable by setting `AppFlags.crashlyticsEnabled = false`.
+- If issues persist, revert the enabling commit.

--- a/docs/specs/TKT-204_v1.md
+++ b/docs/specs/TKT-204_v1.md
@@ -1,0 +1,43 @@
+# TKT-204: Crashlytics Error Reporting
+
+## Context
+Current error handling only logs to the console. We need a gated Crashlytics
+integration to collect runtime errors while respecting performance budgets and
+privacy.
+
+## Requirements
+- Add a `CRASHLYTICS_ENABLED` runtime flag.
+- When enabled, forward errors to `FirebaseCrashlytics`.
+- Document flag usage and rollback plan.
+- Ensure no sensitive data is captured.
+
+## Data Contracts
+No new schemas or persistent data.
+
+## Acceptance Criteria
+- Errors log via `developer.log`.
+- When `CRASHLYTICS_ENABLED` is `true`, errors are forwarded to Crashlytics.
+- When the flag is `false`, Crashlytics is not invoked.
+
+## Runtime Flags
+- `CRASHLYTICS_ENABLED` (bool, default `false`).
+
+## Metrics & Budgets
+- Track Crashlytics error counts.
+- p95 latency < 800 ms.
+- Storage/egress growth < 20% MoM.
+
+## Risks
+- **Performance overhead** — mitigate by gating with flag.
+- **Sensitive data leakage** — only send error strings and stack traces.
+- **Misconfiguration** — document enable/disable steps.
+- **Dependency bloat** — track via DEP record.
+- **Rollout issues** — provide quick rollback.
+
+## Test Plan
+- Unit test verifying Crashlytics call when flag is on and no-op when off.
+- Run full test suite and `flutter analyze`.
+
+## Rollback Steps
+- Set `CRASHLYTICS_ENABLED` to `false` to disable reporting.
+- If needed, revert this change via Git.

--- a/lib/utils/app_flags.dart
+++ b/lib/utils/app_flags.dart
@@ -8,4 +8,7 @@ class AppFlags {
 
   /// Navigation variant flag. Defaults to 'v1'.
   static String navVariant = 'v1';
+
+  /// Crash reporting toggle. Defaults to `false`.
+  static bool crashlyticsEnabled = false;
 }

--- a/lib/utils/error_reporter.dart
+++ b/lib/utils/error_reporter.dart
@@ -1,14 +1,27 @@
+import 'dart:async';
 import 'dart:developer' as developer;
 
-/// Centralized error reporting stub.
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+
+import 'app_flags.dart';
+
+typedef ErrorRecorder = Future<void> Function(Object error, StackTrace? stackTrace);
+
+ErrorRecorder errorRecorder =
+    (error, stack) => FirebaseCrashlytics.instance.recordError(error, stack);
+
+/// Centralized error reporting.
 ///
-/// Logs the [error] with a timestamp. Integration points for services
-/// like Crashlytics or Sentry can be added later.
+/// Logs the [error] with a timestamp and forwards to Crashlytics when
+/// `AppFlags.crashlyticsEnabled` is true.
 class ErrorReporter {
   /// Report an [error] and optional [stackTrace].
   static void report(Object error, [StackTrace? stackTrace]) {
     final String ts = DateTime.now().toIso8601String();
     developer.log('[' + ts + '] ' + error.toString(), stackTrace: stackTrace);
-    // TODO: Hook into Crashlytics or Sentry.
+    if (AppFlags.crashlyticsEnabled) {
+      // Only forward error strings and stack traces to avoid sensitive data.
+      unawaited(errorRecorder(error, stackTrace));
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   firebase_storage: ^11.7.5
   firebase_messaging: ^14.9.0
   firebase_analytics: ^10.10.0 # Existing dependency for analytics events
+  firebase_crashlytics: ^3.5.6
   # State management and connectivity.
   provider: ^6.1.2
   connectivity_plus: ^6.0.3

--- a/test/error_reporter_test.dart
+++ b/test/error_reporter_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/utils/app_flags.dart';
+import 'package:fouta_app/utils/error_reporter.dart';
+
+void main() {
+  late ErrorRecorder originalRecorder;
+
+  setUp(() {
+    originalRecorder = errorRecorder;
+    AppFlags.crashlyticsEnabled = false;
+  });
+
+  tearDown(() {
+    errorRecorder = originalRecorder;
+    AppFlags.crashlyticsEnabled = false;
+  });
+
+  test('forwards error to Crashlytics when enabled', () {
+    AppFlags.crashlyticsEnabled = true;
+    Object? seenError;
+    StackTrace? seenStack;
+    errorRecorder = (error, stack) async {
+      seenError = error;
+      seenStack = stack;
+    };
+    final err = Exception('boom');
+    final st = StackTrace.current;
+    ErrorReporter.report(err, st);
+    expect(seenError, err);
+    expect(seenStack, st);
+  });
+
+  test('no-op when disabled', () {
+    AppFlags.crashlyticsEnabled = false;
+    bool called = false;
+    errorRecorder = (error, stack) async {
+      called = true;
+    };
+    ErrorReporter.report(Exception('boom'));
+    expect(called, false);
+  });
+}


### PR DESCRIPTION
## Summary
- add CRASHLYTICS_ENABLED runtime flag and docs
- forward errors to FirebaseCrashlytics when flag is on
- test Crashlytics call and document flag usage

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: package.json and lockfile mismatch)*
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_689e44172c64832b847f3e9b4eda1f0c