### PR TITLE
Add purchase intent API and payments feature flag

### DIFF
--- a/docs/payments/README.md
+++ b/docs/payments/README.md
@@ -14,3 +14,20 @@ This directory tracks payment integration notes.
 - All intents are marked `pending` and contain no sensitive data.
 - Review provider OAuth scopes and PCI compliance before enabling.
 
+## PAYMENTS_ENABLED flag
+Payments are compile-time flag gated.
+
+Enable at build time:
+- Android:
+  flutter run --dart-define=PAYMENTS_ENABLED=true
+- iOS:
+  flutter run --dart-define=PAYMENTS_ENABLED=true
+
+## Service API
+MonetizationService.createPurchaseIntent({
+  required double amount,
+  required String currency,
+  required String productId,
+  required String createdBy,
+})
+

--- a/lib/features/marketplace/product_detail_screen.dart
+++ b/lib/features/marketplace/product_detail_screen.dart
@@ -3,7 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 
 import '../../screens/chat_screen.dart';
 import 'marketplace_service.dart';
-import '../monetization/monetization_service.dart';
+import 'package:fouta_app/features/monetization/monetization_service.dart';
 
 class ProductDetailScreen extends StatelessWidget {
   const ProductDetailScreen({super.key, required this.product});

--- a/lib/features/monetization/monetization_service.dart
+++ b/lib/features/monetization/monetization_service.dart
@@ -1,3 +1,7 @@
+// Payments feature flag (compile-time)
+const bool PAYMENTS_ENABLED =
+    bool.fromEnvironment('PAYMENTS_ENABLED', defaultValue: false);
+
 abstract class IPaymentProvider {
   Future<String> createTip({
     required double amount,
@@ -80,5 +84,22 @@ class MonetizationService {
     );
   }
 
-  // Add similar facade methods for subscription or purchase as needed using _provider.
+  Future<String> createPurchaseIntent({
+    required double amount,
+    required String currency,
+    required String productId,
+    required String createdBy,
+  }) {
+    if (amount <= 0) {
+      throw ArgumentError.value(amount, 'amount', 'must be > 0');
+    }
+    return _provider.createPurchase(
+      amount: amount,
+      currency: currency,
+      productId: productId,
+      createdBy: createdBy,
+    );
+  }
+
+  // Add similar facade methods for subscription as needed using _provider.
 }

--- a/lib/screens/seller_profile_screen.dart
+++ b/lib/screens/seller_profile_screen.dart
@@ -3,8 +3,7 @@ import 'package:flutter/material.dart';
 
 import '../features/marketplace/marketplace_service.dart';
 import '../features/marketplace/product_card.dart';
-import '../features/monetization/monetization_service.dart';
-import '../utils/app_flags.dart';
+import 'package:fouta_app/features/monetization/monetization_service.dart';
 import 'chat_screen.dart';
 
 class SellerProfileScreen extends StatelessWidget {
@@ -57,9 +56,10 @@ class SellerProfileScreen extends StatelessWidget {
                     }
                     if (!PAYMENTS_ENABLED) {
                       ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('Payments disabled')),
+                        const SnackBar(
+                          content: Text('Payments disabled—coming soon'),
+                        ),
                       );
-
                       return;
                     }
                     final id = await monetization.createTipIntent(


### PR DESCRIPTION
## Summary
- add `PAYMENTS_ENABLED` compile-time flag in monetization service
- expose `createPurchaseIntent` to wrap provider purchase call
- gate seller profile payments UI and update documentation

## Testing
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: lock file out of sync)*
- `npm test --if-present` *(fails: module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e70661dcc832b9f03b59b2a0e6855