### PR TITLE
Docs: No-conflict Codex prompts + normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto eol=lf
+*.sh text eol=lf
+*.md text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,12 @@ Rationale: This guarantees deterministic, reviewable updates and consistent mult
 - **Budgets:** CI must fail if p95 latency exceeds 800 ms or if storage/egress grows more than 20 % month‑over‑month.
 - **Auth screens:** No bottom nav on Login/Signup.
 
+### No-Conflict Codex Prompts
+- See [docs/process/no-conflict-codex-prompts.md](docs/process/no-conflict-codex-prompts.md)
+- One ticket → one branch → one small PR
+- Avoid touching files already edited by open PRs
+- Prefer additive edits; do not mass-reformat
+
 ### Multi‑role awareness
 The AI must integrate the perspectives of PM, Developer, Tester, Designer, DevOps, Data, Security, Accessibility, and Product in every response. For each request, it should explicitly address requirements and acceptance criteria (PM), implementation details (Dev), testing needs (Tester), UI/a11y considerations (Designer), deployment and cost impacts (DevOps), data and migrations (Data), security/privacy concerns (Security), and overall policy compliance (Product).
 

--- a/README.md
+++ b/README.md
@@ -410,7 +410,8 @@ All triggers must respect flags, frequency caps, and user controls.
 ## Change Process
 All changes to project code or documentation must be initiated and executed via Codex prompts.
 
-Do not push manual edits directly.
+- All changes use conflict-safe Codex prompts (see [docs/process/no-conflict-codex-prompts.md](docs/process/no-conflict-codex-prompts.md)).
+- Do not push manual edits directly.
 
 Each change should come as a clear, reviewable Codex prompt that:
 

--- a/docs/process/no-conflict-codex-prompts.md
+++ b/docs/process/no-conflict-codex-prompts.md
@@ -1,0 +1,24 @@
+# No-Conflict Codex Prompts
+
+Guidelines for using Codex prompts to minimize merge conflicts.
+
+## Rules
+Prompts must:
+- Branch from the latest `dev` and merge fast-forward only.
+- Change the smallest possible surface.
+- Avoid editing the same file touched by any open PR.
+- Prefer additive changes (append, new files, new methods) over rewriting existing blocks.
+- Run `dart format .` and use 2-space indentation.
+- Avoid reordering imports unless required.
+- Preserve copyright and license headers.
+- Include acceptance criteria and a rollback note.
+
+## Checklist (Before opening PR)
+- [ ] Base branch is up to date with `dev`.
+- [ ] Changes are scoped to minimal lines.
+- [ ] No overlap with files modified by open PRs.
+- [ ] Additive changes only; no mass refactors.
+- [ ] `dart format .` has been run with 2-space indentation.
+- [ ] Imports unchanged unless necessary.
+- [ ] Copyright and license headers intact.
+- [ ] PR description lists acceptance criteria and rollback plan.


### PR DESCRIPTION
Adds guidance for conflict-safe Codex prompts and normalizes line endings to reduce merge noise.

------
https://chatgpt.com/codex/tasks/task_e_689eafcb71bc832b80ccd2606970e7f7