### PR TITLE
Marketplace: purchase intent call alignment

### DIFF
--- a/lib/features/marketplace/product_detail_screen.dart
+++ b/lib/features/marketplace/product_detail_screen.dart
@@ -39,7 +39,7 @@ class ProductDetailScreen extends StatelessWidget {
               children: [
                 Text(product.title, style: Theme.of(context).textTheme.titleLarge),
                 const SizedBox(height: 8),
-                Text('${product.currency}${product.price.toStringAsFixed(2)}'),
+                Text('${product.priceCurrency}${product.priceAmount.toStringAsFixed(2)}'),
                 const SizedBox(height: 8),
                 Text('Seller: ${product.sellerId}'),
                 if (product.description != null) ...[
@@ -50,8 +50,8 @@ class ProductDetailScreen extends StatelessWidget {
                 ElevatedButton(
                   onPressed: () async {
                     final id = await monetization.createPurchaseIntent(
-                      amount: product.price,
-                      currency: product.currency,
+                      amount: product.priceAmount,
+                      currency: product.priceCurrency,
                       productId: product.id,
                       createdBy: user?.uid ?? 'anon',
                     );


### PR DESCRIPTION
## Summary
- align purchase intent call with MonetizationService API

## Testing
- `flutter pub get` *(fails: command not found: flutter)*
- `flutter analyze` *(fails: command not found: flutter)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found: dart)*
- `flutter test --no-pub --coverage` *(fails: command not found: flutter)*
- `npm ci` *(fails: npm ci can only install packages when package.json and lock file are in sync)*
- `npm test --if-present` *(fails: Cannot find module 'firebase-functions/v2/scheduler')*
- `flutter build web --release` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689eb00b4190832bac9649a64bd7c8fc