### PR TITLE
Groups: moderator role scaffold (low-conflict)

### DIFF
--- a/docs/features/groups_roles.md
+++ b/docs/features/groups_roles.md
@@ -1,0 +1,3 @@
+# Group Roles
+
+Defines owner, moderator, and member roles for groups. Enforcement and write operations will be added in a later PR.

--- a/lib/features/groups/groups_service.dart
+++ b/lib/features/groups/groups_service.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 
 import '../../main.dart';
 import '../../utils/json_safety.dart';
+import 'models/group_roles.dart';
 
 class Group {
   Group({
@@ -176,4 +177,14 @@ class GroupsService {
     }
     if (update.isNotEmpty) await doc.update(update);
   }
+}
+
+Future<void> addModerator(String groupId, String uid) async {
+  // TODO: implement write to roles map; for now just stub to keep PR small
+  GroupRole.moderator;
+}
+
+Future<void> removeModerator(String groupId, String uid) async {
+  // TODO: implement write to roles map; for now just stub to keep PR small
+  GroupRole.moderator;
 }

--- a/lib/features/groups/models/group_roles.dart
+++ b/lib/features/groups/models/group_roles.dart
@@ -1,0 +1,2 @@
+enum GroupRole { owner, moderator, member }
+


### PR DESCRIPTION
Adds a roles enum and stub service methods without modifying existing logic, to avoid conflicts.

## Summary
- add `GroupRole` enum for owner, moderator, and member
- stub `addModerator`/`removeModerator` helpers for future implementation
- document planned role semantics

## Risks
1. Stub functions may be mistakenly invoked in production – flag with TODO comments until implemented.
2. Enum currently unused in most places – follow-up work will integrate and remove dead code.
3. Duplicate top-level helpers share names with class methods – review before wiring to avoid ambiguity.
4. Functions tests failed under current Node setup – ensure lockfile and Node version are synced in CI.
5. Missing Flutter/Dart tooling locally prevented running Dart tests – verify CI has proper SDKs.

## Test Plan
- `flutter pub get` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `(functions) npm ci` *(fails: lockfile out of sync and engine mismatch)*
- `(functions) npm test --if-present` *(fails: test failures)*

## Migration
- none

------
https://chatgpt.com/codex/tasks/task_e_689eb01e478c832bb33452b50e812576