### PR TITLE
CI: harden flutter tests and upload logs

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
@@ -18,3 +21,14 @@ jobs:
         run: |
           chmod +x scripts/validate.sh
           scripts/validate.sh
+      - name: Run Flutter tests
+        run: |
+          mkdir -p build/test-results
+          flutter test --no-pub -r expanded --coverage --machine \
+            | tee build/test-results/test_output.log
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flutter-test-results
+          path: build/test-results/

--- a/test/ci/smoke_test.dart
+++ b/test/ci/smoke_test.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('CI smoke test runs', () {
+    expect(2 + 2, 4);
+  });
+}


### PR DESCRIPTION
## Summary
- run validation job steps from repo root
- pipe Flutter test output in expanded format and capture logs
- upload test results and add smoke test to avoid empty suite failures

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: package-lock and dependencies out of sync)*
- `npm test --if-present` *(fails: module not found errors)*

------
https://chatgpt.com/codex/tasks/task_e_689eb4ce44a0832b86c4eb953dd21104