### PR TITLE
Docs: Trust & Safety pipeline + privacy controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,10 @@ Data models are stored under `artifacts/\$APP_ID/public/data/users/{uid}/safety`
 - `muted_words` document field:
   - `words` (`List<String>`; lowercased)
 
+Additional documentation lives under `docs/safety`:
+- [Moderation pipeline](docs/safety/moderation-pipeline.md)
+- [Privacy controls](docs/safety/privacy-controls.md)
+
 ## Troubleshooting
 
 If constructors use non-const initializers (e.g., FirebaseAuth, service instances), remove const from widget constructors.

--- a/docs/safety/moderation-pipeline.md
+++ b/docs/safety/moderation-pipeline.md
@@ -1,0 +1,28 @@
+# Moderation Pipeline
+
+Defines the trust and safety flow for content submitted to Fouta.
+
+## Pre-publish Checks
+- Automated scans for malware, CSAM, and policy keywords.
+- Media sizing and format validation.
+- Client-side nudges for potentially sensitive content.
+
+## Queues
+- Flagged submissions enter reviewer queues with priority buckets.
+- Escalations route to specialized teams for legal or high-risk cases.
+
+## Appeals
+- Users can appeal removals from their safety dashboard.
+- Appeals track reviewer decisions, timestamps, and reviewer IDs.
+
+## Audit Logging
+- All moderation actions append to an immutable log.
+- Entries include actor, rationale, target IDs, and before/after states.
+
+## Rate Limits
+- Throttle report volume and submission retries to deter spam.
+- Exponential backoff resets after successful publishing.
+
+## User Feedback Loops
+- Notices explain why content was restricted and reference policy.
+- In-product surveys gather satisfaction data on moderation outcomes.

--- a/docs/safety/privacy-controls.md
+++ b/docs/safety/privacy-controls.md
@@ -1,0 +1,18 @@
+# Privacy Controls
+
+Outlines user options for managing visibility and interactions.
+
+## Visibility Scopes
+- Public: visible to anyone.
+- Followers: visible to approved followers only.
+- Private: content restricted to the author.
+
+## Block and Mute UX
+- Blocking hides profiles, messages, and interactions bi-directionally.
+- Muting filters posts without notifying the other party.
+- Confirmation dialogs clarify consequences of each action.
+
+## Data Export and Delete
+- Self-service export delivers a portable archive via email.
+- Delete requests schedule account and content purge after verification.
+- Audit entries record who initiated and completed the process.


### PR DESCRIPTION
## Summary
- document moderation pipeline from pre-publish checks to appeals
- capture privacy control options including visibility and data export/delete flows

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `cd functions && npm ci && npm test --if-present` *(fails: lock file out of sync)*

------
https://chatgpt.com/codex/tasks/task_e_689eebf9889c832ba945502a1e0ba6e0