### PR TITLE
Profile/Seller: tiered DS + access audit

### DIFF
--- a/docs/design/feature-access-audit.md
+++ b/docs/design/feature-access-audit.md
@@ -1,0 +1,22 @@
+# Profile & Seller Feature Access Audit
+
+## Profile Screen
+- **Edit Profile**: Primary button displayed prominently beneath the profile header for the owner.
+- **Settings**: Secondary button beside Edit Profile offering quick access to account configuration.
+- **Follow/Unfollow**: Primary action when viewing another user, placed alongside communication options.
+- **Message**: Secondary button next to Follow, allowing direct contact.
+- **Content Tabs**: Posts, Shorts, and About tabs surface browsing options below the action area.
+
+**Assessment:** Placement of personal actions (edit, settings) mirrors expected editing flow. For other profiles, social actions (follow, message) are grouped logically, improving discovery before content.
+
+## Seller Profile Screen
+- **Message seller**: Secondary button enabling communication, shown above product listings.
+- **Support Creator**: Primary button for tips, adjacent to messaging for clear monetary entry.
+- **View Products**: Product grid appears after action buttons, matching shopping flow.
+
+**Assessment:** Monetary and communication actions are grouped at the top, keeping commerce features before browsing inventory.
+
+## Recommendations
+- Consider a dedicated action bar to host future features (e.g., share profile, report).
+- Explore contextual placement for "Support Creator" on standard profiles when payments expand.
+- Revisit product grid ordering if more seller tools are introduced.

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -17,6 +17,7 @@ import 'package:fouta_app/models/media_item.dart';
 import 'package:fouta_app/widgets/post_card_widget.dart';
 import 'package:fouta_app/widgets/fouta_button.dart';
 import 'package:fouta_app/screens/create_post_screen.dart';
+import 'package:fouta_app/screens/unified_settings_screen.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:fouta_app/utils/firestore_paths.dart';
 import 'package:fouta_app/widgets/skeletons/profile_skeleton.dart';
@@ -680,46 +681,70 @@ class _ProfileScreenState extends State<ProfileScreen>
     final Widget actionButtons = isMyProfile
         ? Padding(
             padding: const EdgeInsets.only(bottom: 20),
-            child: ElevatedButton(
-              onPressed: () {
-                if (_userData != null) {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => EditProfileScreen(
-                        uid: widget.userId,
-                        initialData: _userData!,
+            child: Column(
+              children: [
+                FoutaButton(
+                  label: 'Edit Profile',
+                  onPressed: () {
+                    if (_userData != null) {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => EditProfileScreen(
+                            uid: widget.userId,
+                            initialData: _userData!,
+                          ),
+                        ),
+                      );
+                    }
+                  },
+                  expanded: true,
+                ),
+                const SizedBox(height: 8),
+                FoutaButton(
+                  label: 'Settings',
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const UnifiedSettingsScreen(),
                       ),
-                    ),
-                  );
-                }
-              },
-              child: const Text('Edit Profile'),
+                    );
+                  },
+                  primary: false,
+                  expanded: true,
+                ),
+              ],
             ),
           )
         : (currentUser != null && !currentUser.isAnonymous)
             ? Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  ElevatedButton(
-                    onPressed: () => _toggleFollow(
-                        currentUser.uid, widget.userId, isFollowing),
-                    child: Text(isFollowing ? 'Unfollow' : 'Follow'),
+                  Expanded(
+                    child: FoutaButton(
+                      label: isFollowing ? 'Unfollow' : 'Follow',
+                      onPressed: () => _toggleFollow(
+                          currentUser.uid, widget.userId, isFollowing),
+                    ),
                   ),
                   const SizedBox(width: 10),
-                  ElevatedButton(
-                    onPressed: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => ChatScreen(
-                            otherUserId: widget.userId,
-                            otherUserName: displayName,
+                  Expanded(
+                    child: FoutaButton(
+                      label: 'Message',
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => ChatScreen(
+                              otherUserId: widget.userId,
+                              otherUserName: displayName,
+                            ),
                           ),
-                        ),
-                      );
-                    },
-                    child: const Text('Message'),
+                        );
+                      },
+                      primary: false,
+                    ),
                   ),
                 ],
               )
@@ -921,7 +946,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
             }),
           ),
           const SizedBox(height: 20),
-          ElevatedButton(onPressed: _save, child: const Text('Save')),
+          FoutaButton(label: 'Save', onPressed: _save, expanded: true),
         ],
       ),
     );

--- a/lib/screens/seller_profile_screen.dart
+++ b/lib/screens/seller_profile_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import '../features/marketplace/marketplace_service.dart';
 import '../features/marketplace/product_card.dart';
 import 'package:fouta_app/features/monetization/monetization_service.dart';
+import 'package:fouta_app/widgets/fouta_button.dart';
 import 'chat_screen.dart';
 
 class SellerProfileScreen extends StatelessWidget {
@@ -28,9 +29,11 @@ class SellerProfileScreen extends StatelessWidget {
         children: [
           Padding(
             padding: const EdgeInsets.all(16),
-            child: Row(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                ElevatedButton(
+                FoutaButton(
+                  label: 'Message seller',
                   onPressed: () {
                     Navigator.push(
                       context,
@@ -39,14 +42,15 @@ class SellerProfileScreen extends StatelessWidget {
                       ),
                     );
                   },
-                  child: const Text('Message seller'),
+                  primary: false,
+                  expanded: true,
                 ),
-                const SizedBox(width: 8),
-                ElevatedButton(
+                const SizedBox(height: 8),
+                FoutaButton(
+                  label: 'Support Creator',
                   onPressed: () async {
                     const amount = 5.0;
                     if (amount <= 0) {
-
                       ScaffoldMessenger.of(context).showSnackBar(
                         const SnackBar(
                           content: Text('Amount must be greater than zero'),
@@ -80,7 +84,7 @@ class SellerProfileScreen extends StatelessWidget {
                     }
                     // TODO: connect to payment provider once approved.
                   },
-                  child: const Text('Support Creator'),
+                  expanded: true,
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- swap profile action buttons for Tier 2 FoutaButton variants and surface Settings alongside Edit Profile
- group seller communication and monetary actions with Tier 2 buttons
- document feature access audit for profile-related screens

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: package-lock mismatch)*
- `npm test --if-present` *(fails: cannot find firebase modules)*

------
https://chatgpt.com/codex/tasks/task_e_689ef2c6855c832b95b6cbebc62e2143