### PR TITLE
Marketplace: define Product model and unblock ProductDetail

### DIFF
--- a/lib/features/marketplace/product_detail_screen.dart
+++ b/lib/features/marketplace/product_detail_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
 import '../../screens/chat_screen.dart';
-import 'marketplace_service.dart';
+import 'package:fouta_app/features/marketplace/marketplace_service.dart';
 import 'package:fouta_app/features/monetization/monetization_service.dart';
 import '../../widgets/fouta_button.dart';
 
@@ -13,7 +13,7 @@ class ProductDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final images = product.urls;
+    final images = product.imageUris.map((u) => u.toString()).toList();
     final user = FirebaseAuth.instance.currentUser;
     final monetization = MonetizationService();
     return Scaffold(
@@ -40,7 +40,7 @@ class ProductDetailScreen extends StatelessWidget {
               children: [
                 Text(product.title, style: Theme.of(context).textTheme.titleLarge),
                 const SizedBox(height: 8),
-                Text('${product.priceCurrency}${product.priceAmount.toStringAsFixed(2)}'),
+                Text('${product.priceCurrency} ${product.priceAmount.toStringAsFixed(2)}'),
                 const SizedBox(height: 8),
                 Text('Seller: ${product.sellerId}'),
                 if (product.description != null) ...[

--- a/test/marketplace/product_model_test.dart
+++ b/test/marketplace/product_model_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fouta_app/features/marketplace/marketplace_service.dart';
+
+void main() {
+  test('Product serialization roundtrip keeps price fields', () {
+    final p = Product(
+      id: 'p1',
+      title: 'Lamp',
+      priceAmount: 19.5,
+      priceCurrency: 'USD',
+      sellerId: 'u1',
+      description: 'Desk lamp',
+    );
+
+    final map = p.toMap();
+    final p2 = Product.fromMap('p1', map);
+
+    expect(p2.priceAmount, 19.5);
+    expect(p2.priceCurrency, 'USD');
+    expect(p2.title, 'Lamp');
+  });
+}
+


### PR DESCRIPTION
## Summary
- define `Product` model with priceAmount/priceCurrency and basic serialization
- add stubbed `getProductById` and `listProducts` queries in MarketplaceService
- wire ProductDetail to new fields and add unit test for serialization

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci && npm test --if-present` *(fails: npm ci lockfile mismatch)*


------
https://chatgpt.com/codex/tasks/task_e_689efba7ee0c832ba302cfc70c4c12bb