### PR TITLE
Functions: safety checks + scheduled posts (flag-gated)

### DIFF
--- a/docs/safety/pipeline.md
+++ b/docs/safety/pipeline.md
@@ -1,0 +1,8 @@
+# Safety Pipeline
+
+Server-side scheduled posts run through a minimal safety check before publishing.
+
+- `checkSafetyRules` validates text length, forbidden terms, and that media URLs are HTTPS.
+- `schedulePosts` runs when `SCHEDULED_POSTS_ENABLED=true`.
+  - Passing posts are written to `artifacts/${APP_ID}/public/data/posts`.
+  - Rejected posts are written to `artifacts/${APP_ID}/public/data/moderation/scheduled/<id>` with the failure reason and creator info.

--- a/functions/src/safetyRules.ts
+++ b/functions/src/safetyRules.ts
@@ -1,31 +1,16 @@
-
-export interface SafetyResult {
-  ok: boolean;
-  reason?: string;
-}
-
-const FORBIDDEN_WORDS = ['spam', 'scam', 'fake'];
-
-export function checkSafetyRules(data: any): SafetyResult {
-  const content = (data?.content || '').trim();
-  if (!content) {
-    return { ok: false, reason: 'empty-content' };
-  }
-  if (content.length > 5000) {
-    return { ok: false, reason: 'too-long' };
-  }
-  const lower = content.toLowerCase();
-  if (FORBIDDEN_WORDS.some((w) => lower.includes(w))) {
-    return { ok: false, reason: 'forbidden-content' };
+export function checkSafetyRules(data: any): { ok: boolean; reason?: string } {
+  const text = (data?.content ?? '').toString().trim();
+  if (!text) return { ok: false, reason: 'empty_content' };
+  if (text.length > 5000) return { ok: false, reason: 'content_too_long' };
+  const forbidden = ['hateword1', 'slur1']; // placeholder list
+  const lower = text.toLowerCase();
+  if (forbidden.some(w => lower.includes(w))) {
+    return { ok: false, reason: 'forbidden_terms' };
   }
   const media = data?.media;
-  if (Array.isArray(media)) {
-    for (const url of media) {
-      if (typeof url !== 'string' || !url.startsWith('https://')) {
-        return { ok: false, reason: 'insecure-media-url' };
-      }
-    }
+  const urls: string[] = Array.isArray(media) ? media : (media?.urls ?? []);
+  if (urls.some(u => !/^https:\/\//i.test(String(u)))) {
+    return { ok: false, reason: 'insecure_media_url' };
   }
   return { ok: true };
-
 }

--- a/functions/src/schedulePosts.ts
+++ b/functions/src/schedulePosts.ts
@@ -33,6 +33,7 @@ export async function publishDueScheduledPosts(
           .doc(doc.id)
           .set({
             reason: result.reason,
+            createdBy: user.id,
             createdAt: admin.firestore.FieldValue.serverTimestamp(),
           });
       }
@@ -46,6 +47,7 @@ export const schedulePosts = functions.pubsub
   .schedule('every 5 minutes')
   .onRun(async () => {
     if (process.env.SCHEDULED_POSTS_ENABLED !== 'true') {
+      functions.logger.info('scheduled posts disabled');
       return null;
     }
     const now = admin.firestore.Timestamp.now();

--- a/functions/test/safetyRules.test.ts
+++ b/functions/test/safetyRules.test.ts
@@ -10,24 +10,24 @@ test('accepts valid content', () => {
 test('rejects empty content', () => {
   const res = checkSafetyRules({content: ''});
   assert.equal(res.ok, false);
-  assert.equal(res.reason, 'empty-content');
+  assert.equal(res.reason, 'empty_content');
 });
 
 test('rejects too long content', () => {
   const long = 'a'.repeat(5001);
   const res = checkSafetyRules({content: long});
   assert.equal(res.ok, false);
-  assert.equal(res.reason, 'too-long');
+  assert.equal(res.reason, 'content_too_long');
 });
 
 test('rejects insecure media', () => {
   const res = checkSafetyRules({content: 'ok', media: ['http://a']});
   assert.equal(res.ok, false);
-  assert.equal(res.reason, 'insecure-media-url');
+  assert.equal(res.reason, 'insecure_media_url');
 });
 
 test('rejects forbidden words', () => {
-  const res = checkSafetyRules({content: 'this is spam'});
+  const res = checkSafetyRules({content: 'contains hateword1'});
   assert.equal(res.ok, false);
-  assert.equal(res.reason, 'forbidden-content');
+  assert.equal(res.reason, 'forbidden_terms');
 });


### PR DESCRIPTION
## Summary
- add server-side content safety checks
- gate scheduled posts on SCHEDULED_POSTS_ENABLED and route rejects to moderation
- document safety and moderation pipeline

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: missing dependencies)*
- `npm test --if-present` *(fails: Cannot find module 'firebase-functions/v2/scheduler')*


------
https://chatgpt.com/codex/tasks/task_e_689f5426a3cc832b927c12ef0da75180