### PR TITLE
Ops: Firestore index stubs and docs

### DIFF
--- a/docs/ops/firestore-indexes.md
+++ b/docs/ops/firestore-indexes.md
@@ -1,0 +1,17 @@
+# Firestore Indexes
+
+The project seeds composite indexes via [`firestore.indexes.json`](../../firestore.indexes.json).
+
+## Adding or updating an index
+
+1. Run your query. If Firestore returns `FAILED_PRECONDITION: The query requires an index`,
+   open the URL provided in the error message. It leads directly to the Firebase console
+   with the fields prefilled.
+2. Create the index in the console. Wait for it to build.
+3. Back in the repo, export the definitions to `firestore.indexes.json`:
+   ```bash
+   firebase firestore:indexes
+   ```
+4. Commit the updated file so all environments provision the same index.
+
+Include the console URL in your PR description for reviewers.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,29 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "posts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "visibility", "op": "EQUAL" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "products",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "sellerId", "op": "EQUAL" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "threadId", "op": "EQUAL" },
+        { "fieldPath": "sentAt", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
## Summary
- seed common Firestore composite indexes
- document how to add and export indexes

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `(cd functions && npm ci && npm test --if-present)` *(fails: package-lock mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_689f543e4238832bac5f93c77fa62a3c