### PR TITLE
Marketplace: stub data wiring + empty states

### DIFF
--- a/docs/features/marketplace_data.md
+++ b/docs/features/marketplace_data.md
@@ -1,0 +1,11 @@
+# Marketplace data
+
+Marketplace screens currently rely on stubbed methods in `MarketplaceService` to provide demo products when the backend is unavailable. This keeps the UI functional even when offline.
+
+## Switching to Firestore
+- Replace stub implementations with real Firestore queries/writes.
+- `streamProducts` should read from the `products` collection with the same `limit` and filter parameters.
+- `getProductById` should fetch a document by ID from Firestore.
+- Remove or adjust demo data generators once the backend is wired.
+
+These stubs enable UI development while the backend is built and can be removed once Firestore integration is complete.

--- a/lib/features/marketplace/product_detail_screen.dart
+++ b/lib/features/marketplace/product_detail_screen.dart
@@ -6,85 +6,108 @@ import 'package:fouta_app/features/marketplace/marketplace_service.dart';
 import 'package:fouta_app/features/monetization/monetization_service.dart';
 import '../../widgets/fouta_button.dart';
 
-class ProductDetailScreen extends StatelessWidget {
+class ProductDetailScreen extends StatefulWidget {
   const ProductDetailScreen({super.key, required this.product});
 
   final Product product;
 
   @override
+  State<ProductDetailScreen> createState() => _ProductDetailScreenState();
+}
+
+class _ProductDetailScreenState extends State<ProductDetailScreen> {
+  final MarketplaceService _service = MarketplaceService();
+  late Future<Product> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _service.getProductById(widget.product.id);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final images = product.imageUris.map((u) => u.toString()).toList();
-    final user = FirebaseAuth.instance.currentUser;
-    final monetization = MonetizationService();
-    return Scaffold(
-      appBar: AppBar(title: Text(product.title)),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Expanded(
-            child: images.isNotEmpty
-                ? PageView(
-                    children: images
-                        .map((u) => Image.network(u, fit: BoxFit.contain))
-                        .toList(),
-                  )
-                : Container(
-                    color: Colors.grey.shade300,
-                    child: const Center(child: Icon(Icons.image, size: 48)),
-                  ),
-          ),
-          Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(product.title, style: Theme.of(context).textTheme.titleLarge),
-                const SizedBox(height: 8),
-                Text('${product.priceCurrency} ${product.priceAmount.toStringAsFixed(2)}'),
-                const SizedBox(height: 8),
-                Text('Seller: ${product.sellerId}'),
-                if (product.description != null) ...[
-                  const SizedBox(height: 8),
-                  Text(product.description!),
-                ],
-                const SizedBox(height: 16),
-                FoutaButton(
-                  label: 'Buy',
-                  onPressed: () async {
-                    final id = await monetization.createPurchaseIntent(
-                      amount: product.priceAmount,
-                      currency: product.priceCurrency,
-                      productId: product.id,
-                      createdBy: user?.uid ?? 'anon',
-                    );
-                    if (context.mounted) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text('Purchase intent: $id')),
-                      );
-                    }
-                    // TODO: Hand off to payment provider once integrated.
-                  },
-                  expanded: true,
-                ),
-                const SizedBox(height: 8),
-                FoutaButton(
-                  label: 'Message Seller',
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => ChatScreen(otherUserId: product.sellerId),
+    return FutureBuilder<Product>(
+      future: _future,
+      builder: (context, snapshot) {
+        final product = snapshot.data ?? widget.product;
+        final images = product.imageUris.map((u) => u.toString()).toList();
+        final user = FirebaseAuth.instance.currentUser;
+        final monetization = MonetizationService();
+        return Scaffold(
+          appBar: AppBar(title: Text(product.title)),
+          body: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: images.isNotEmpty
+                    ? PageView(
+                        children: images
+                            .map((u) => Image.network(u, fit: BoxFit.contain))
+                            .toList(),
+                      )
+                    : Container(
+                        color: Colors.grey.shade300,
+                        child: const Center(child: Icon(Icons.image, size: 48)),
                       ),
-                    );
-                  },
-                  primary: false,
-                  expanded: true,
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(product.title,
+                        style: Theme.of(context).textTheme.titleLarge),
+                    const SizedBox(height: 8),
+                    Text(
+                        '${product.priceCurrency} ${product.priceAmount.toStringAsFixed(2)}'),
+                    const SizedBox(height: 8),
+                    Text('Seller: ${product.sellerId}'),
+                    if (product.description != null) ...[
+                      const SizedBox(height: 8),
+                      Text(product.description!),
+                    ],
+                    const SizedBox(height: 16),
+                    FoutaButton(
+                      label: 'Buy',
+                      onPressed: () async {
+                        final id = await monetization.createPurchaseIntent(
+                          amount: product.priceAmount,
+                          currency: product.priceCurrency,
+                          productId: product.id,
+                          createdBy: user?.uid ?? 'anon',
+                        );
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text('Purchase intent: $id')),
+                          );
+                        }
+                        // TODO: Hand off to payment provider once integrated.
+                      },
+                      expanded: true,
+                    ),
+                    const SizedBox(height: 8),
+                    FoutaButton(
+                      label: 'Message Seller',
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) =>
+                                ChatScreen(otherUserId: product.sellerId),
+                          ),
+                        );
+                      },
+                      primary: false,
+                      expanded: true,
+                    ),
+                  ],
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/screens/marketplace_screen.dart
+++ b/lib/screens/marketplace_screen.dart
@@ -51,6 +51,7 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
       ),
       body: SafeStreamBuilder<List<Product>>(
         stream: _service.streamProducts(
+          limit: 20,
           category: _filters.category,
           minPrice: _filters.minPrice,
           maxPrice: _filters.maxPrice,
@@ -61,16 +62,7 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
           final hasListings = products.any((p) => p.sellerId == userId);
           Widget content;
           if (products.isEmpty) {
-            content = RefreshScaffold(
-              onRefresh: () async {},
-              slivers: const [],
-              empty: const Card(
-                child: Padding(
-                  padding: EdgeInsets.all(24),
-                  child: Text('No listings yet'),
-                ),
-              ),
-            );
+            content = const Center(child: Text('No products'));
           } else {
             content = LayoutBuilder(
               builder: (context, constraints) {


### PR DESCRIPTION
## Summary
- Connect marketplace list to service stub with limit and basic empty-state
- Fetch product details via stub service
- Document stub data behavior and future Firestore switch

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: lock file out of sync)*
- `npm test --if-present`

------
https://chatgpt.com/codex/tasks/task_e_689f54482400832bbc483a45acc3982c