### PR TITLE
UI: Tier-2 button styling (pass 1)

### DIFF
--- a/docs/design/button-usage.md
+++ b/docs/design/button-usage.md
@@ -1,0 +1,17 @@
+# Button usage
+
+Use `FoutaButton` for consistent Tier-2 buttons. Styles map to the current theme's
+colour scheme and should be chosen based on action importance.
+
+| Style | When to use | Example |
+| --- | --- | --- |
+| **Primary** (filled) | The main call-to-action on a screen | `Buy` on product detail, `Support Creator` on seller profile |
+| **Secondary** (outlined) | Supporting actions | `Message Seller` on product detail, `Cancel` in post preview |
+| **Tertiary** (text) | Low emphasis link-style actions | none in this pass |
+| **Destructive** | Actions that remove data or have irreversible effects; use `colorScheme.error` colours | none in this pass |
+
+## Examples
+- Product detail: `FoutaButton(label: 'Buy', primary: true)`
+- Seller profile: `FoutaButton(label: 'Message seller', primary: false)`
+- Create post preview: `FoutaButton(label: 'Post', primary: true)`
+- Create post preview: `FoutaButton(label: 'Cancel', primary: false)`

--- a/lib/features/marketplace/product_detail_screen.dart
+++ b/lib/features/marketplace/product_detail_screen.dart
@@ -4,7 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../../screens/chat_screen.dart';
 import 'package:fouta_app/features/marketplace/marketplace_service.dart';
 import 'package:fouta_app/features/monetization/monetization_service.dart';
-import '../../widgets/fouta_button.dart';
+import 'package:fouta_app/widgets/fouta_button.dart';
 
 class ProductDetailScreen extends StatelessWidget {
   const ProductDetailScreen({super.key, required this.product});
@@ -50,6 +50,7 @@ class ProductDetailScreen extends StatelessWidget {
                 const SizedBox(height: 16),
                 FoutaButton(
                   label: 'Buy',
+                  primary: true,
                   onPressed: () async {
                     final id = await monetization.createPurchaseIntent(
                       amount: product.priceAmount,

--- a/lib/screens/create_post_screen.dart
+++ b/lib/screens/create_post_screen.dart
@@ -457,14 +457,15 @@ class _CreatePostScreenState extends State<CreatePostScreen> {
             ),
           ),
           actions: <Widget>[
-            TextButton(
-              child: const Text('Cancel'),
+            FoutaButton(
+              label: 'Cancel',
+              primary: false,
               onPressed: () {
                 Navigator.of(context).pop(false);
               },
             ),
-            ElevatedButton(
-              child: const Text('Post'),
+            FoutaButton(
+              label: 'Post',
               onPressed: () {
                 Navigator.of(context).pop(true);
               },

--- a/lib/screens/seller_profile_screen.dart
+++ b/lib/screens/seller_profile_screen.dart
@@ -48,6 +48,7 @@ class SellerProfileScreen extends StatelessWidget {
                 const SizedBox(height: 8),
                 FoutaButton(
                   label: 'Support Creator',
+                  primary: true,
                   onPressed: () async {
                     const amount = 5.0;
                     if (amount <= 0) {


### PR DESCRIPTION
## Summary
- replace ad-hoc buttons with `FoutaButton` on product detail, seller profile, and post creation preview dialogs
- document Tier-2 button usage and style examples

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci && npm test --if-present` *(fails: lock file out of sync)*


------
https://chatgpt.com/codex/tasks/task_e_689f545aed6c832ba5c8551d21851734