### PR TITLE
Docs: reinforce conflict-free prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,3 +66,5 @@ The AI must integrate the perspectives of PM, Developer, Tester, Designer, DevOp
   4) PR includes a **rollback plan** and index notes (Firestore queries must be indexable).
 
 When generating prompts for codex, document the flag names, the metrics to track, and the rollback plan.
+
+**Shared prompts MUST NOT cause merge conflicts. Prefer new files or single-file, additive diffs.**

--- a/docs/process/no-conflict-codex-prompts.md
+++ b/docs/process/no-conflict-codex-prompts.md
@@ -22,3 +22,5 @@ Prompts must:
 - [ ] Imports unchanged unless necessary.
 - [ ] Copyright and license headers intact.
 - [ ] PR description lists acceptance criteria and rollback plan.
+
+Runtime changes must be scoped and additive; avoid multi-file refactors in one PR; do not touch files with open PRs.


### PR DESCRIPTION
Adds explicit reminders to keep future AI prompts conflict-free.

------
https://chatgpt.com/codex/tasks/task_e_689f54759170832b97ed7bd36770653f