### PR TITLE
Challenges: nav wiring behind feature flag

### DIFF
--- a/docs/features/challenges/feature-flag.md
+++ b/docs/features/challenges/feature-flag.md
@@ -1,0 +1,19 @@
+# Challenges Feature Flag
+
+The `CHALLENGES_ENABLED` compile-time flag gates the stubbed challenges feed and navigation wiring.
+
+## Usage
+
+### Local
+Run the app with the flag enabled:
+
+```sh
+flutter run --dart-define=CHALLENGES_ENABLED=true
+```
+
+### CI
+Optionally pass the same `--dart-define` to UI test jobs to exercise the stub feed.
+
+## Notes
+- The feed currently uses mock data until backend integrations land.
+- When the flag is off (default), the Challenges route and nav entry are omitted.

--- a/lib/config/feature_flags.dart
+++ b/lib/config/feature_flags.dart
@@ -1,2 +1,5 @@
 /// App feature flags (runtime decisions can read these).
 const bool AR_EXPERIMENTAL = bool.fromEnvironment('AR_EXPERIMENTAL', defaultValue: false);
+/// Centralized feature flags (compile-time via --dart-define).
+const bool CHALLENGES_ENABLED =
+    bool.fromEnvironment('CHALLENGES_ENABLED', defaultValue: false);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,10 @@ import 'firebase_options.dart';
 import 'utils/log_buffer.dart';
 import 'utils/bug_reporter.dart';
 import 'dev/panic_dismiss.dart';
-import 'routes.dart';
+import 'package:fouta_app/config/feature_flags.dart';
+import 'package:fouta_app/features/challenges/challenges_feed_screen.dart'
+    show ChallengesFeedScreen;
+import 'routes.dart' show appRoutes, challengesRoute;
 
 // Define a global constant for the app ID.
 const String APP_ID = 'fouta-app';
@@ -72,7 +75,11 @@ class MyApp extends StatelessWidget {
             darkTheme: AppTheme.dark(),
             themeMode: controller.themeMode,
             navigatorObservers: [PlaybackRouteObserver()],
-            routes: appRoutes(),
+            routes: {
+              ...appRoutes(),
+              if (CHALLENGES_ENABLED)
+                challengesRoute: (_) => const ChallengesFeedScreen(),
+            },
 
             builder: (context, child) => PanicDismiss(
               child: RepaintBoundary(

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -1,9 +1,11 @@
 // lib/routes.dart
 
 import 'package:flutter/widgets.dart';
-import 'features/challenges/challenges_feed_screen.dart';
+
+/// Route name for the Challenges feed.
+const String challengesRoute = '/challenges';
 
 /// Global route table for the application.
 Map<String, WidgetBuilder> appRoutes() => {
-      ChallengesFeedScreen.route: (_) => const ChallengesFeedScreen(),
-    };
+  // existing routes
+};

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -57,6 +57,8 @@ import 'package:fouta_app/screens/search_screen.dart';
 import 'package:fouta_app/widgets/safe_stream_builder.dart';
 import 'package:fouta_app/widgets/safe_future_builder.dart';
 import 'package:fouta_app/utils/error_reporter.dart';
+import 'package:fouta_app/config/feature_flags.dart';
+import 'package:fouta_app/features/challenges/challenges_feed_screen.dart';
 
 
 class HomeScreen extends StatefulWidget {
@@ -79,6 +81,7 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
     GlobalKey<NavigatorState>(),
     GlobalKey<NavigatorState>(),
     GlobalKey<NavigatorState>(),
+    if (CHALLENGES_ENABLED) GlobalKey<NavigatorState>(),
   ];
 
   @override
@@ -268,6 +271,12 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
                 selectedIcon: const _GradientSelectedIcon(Icons.person),
                 label: 'Profile',
               ),
+              if (CHALLENGES_ENABLED)
+                NavigationDestination(
+                  icon: const Icon(Icons.outlined_flag),
+                  selectedIcon: const _GradientSelectedIcon(Icons.flag),
+                  label: 'Challenges',
+                ),
             ],
           ),
           body: Consumer<ConnectivityProvider>(
@@ -329,6 +338,9 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
                     _buildTabNavigator(3, const PeopleTab()),
                     _buildTabNavigator(
                         4, ProfileScreen(userId: currentUser?.uid ?? '')),
+                    if (CHALLENGES_ENABLED)
+                      _buildTabNavigator(
+                          5, const ChallengesFeedScreen()),
                   ],
                 ),
               );
@@ -367,6 +379,12 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
                           selectedIcon: Icon(Icons.person),
                           label: Text('Profile'),
                         ),
+                        if (CHALLENGES_ENABLED)
+                          NavigationRailDestination(
+                            icon: Icon(Icons.outlined_flag),
+                            selectedIcon: Icon(Icons.flag),
+                            label: Text('Challenges'),
+                          ),
                       ],
                     ),
                     const VerticalDivider(width: 1),


### PR DESCRIPTION
Adds CHALLENGES_ENABLED compile-time flag and conditionally registers route/nav item.
Keeps default experience unchanged; enables safe testing of the stub feed.

------
https://chatgpt.com/codex/tasks/task_e_689f94188728832b96c89dfb537cfcb2