### PR TITLE
CI: Fix Storage deploy flag + docs

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           firebase deploy --non-interactive \
             --project "$FIREBASE_PROJECT_ID" \
-            --only firestore:rules,firestore:indexes,storage:rules \
+            --only firestore:rules,firestore:indexes,storage \
             --token "${{ steps.token.outputs.token }}"
 
       - name: Deploy functions (if present)

--- a/docs/history/2025-08-15-storage-flag-fix.md
+++ b/docs/history/2025-08-15-storage-flag-fix.md
@@ -1,0 +1,3 @@
+Fixed CI deploy by switching from --only storage:rules (interpreted as a missing target named rules) to --only storage.
+
+Context: firebase.json already maps the rules file (storage.rules); no targets were defined.

--- a/docs/ops/firebase-service-account.md
+++ b/docs/ops/firebase-service-account.md
@@ -34,14 +34,32 @@ As of 2025-08-15, CI deploys **Cloud Storage rules** alongside Firestore rules a
 
 **CI behavior**
 
-The workflow runs:
+  The workflow runs:
 
-```bash
-firebase deploy --only firestore:rules,firestore:indexes,storage:rules
-```
-which deploys Storage rules without missing-file errors.
+  ```bash
+  firebase deploy --only firestore:rules,firestore:indexes,storage
+  ```
+  which deploys Storage rules using the configuration in `firebase.json`.
 
 **Tips**
 
-- Tighten/relax rules by editing `storage.rules`; CI will deploy on merge.
-- For multi-bucket setups, add Storage targets in `firebase.json` and corresponding rules files; keep the CI `--only storage:rules` filter unchanged.
+  - Tighten/relax rules by editing `storage.rules`; CI will deploy on merge.
+  - For multi-bucket setups, add Storage targets in `firebase.json` and corresponding rules files; include those targets via `--only storage:<name>`.
+
+### 10) Storage deploy flag (important)
+
+Use:
+
+```bash
+firebase deploy --only firestore:rules,firestore:indexes,storage
+```
+
+Do not use `storage:rules`. In the Firebase CLI, `storage:<name>` refers to a Storage target named `<name>` (configured via `firebase target:apply storage <name> <bucket>`).
+
+When `firebase.json` has:
+
+```json
+"storage": { "rules": "storage.rules" }
+```
+
+you deploy those rules with `--only storage`.


### PR DESCRIPTION
## Summary
- Replaces --only storage:rules with --only storage in Firebase deploy workflow.
- Adds documentation clarifying Storage targets vs rules files.
- Adds history note for future archaeology.

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: package-lock mismatch)*
- `npm test --if-present` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_689fc2d352b8832b9eab37c3a8af71e5