### PR TITLE
CI: Correct Storage deploy flag; add storage.rules and docs

### DIFF
--- a/docs/history/2025-08-15-storage-flag-correction.md
+++ b/docs/history/2025-08-15-storage-flag-correction.md
@@ -1,0 +1,5 @@
+Fixed CI deploy by replacing --only storage:rules with --only storage.
+
+Ensures Storage rules from storage.rules (linked in firebase.json) are deployed.
+
+Prevents Firebase CLI error: "Could not find rules for the following storage targets: rules".

--- a/docs/ops/ci-and-firebase.md
+++ b/docs/ops/ci-and-firebase.md
@@ -9,7 +9,7 @@
 
 # Local commands
 - Deploy backend locally (after `firebase login`):
-firebase deploy --only firestore:rules,firestore:indexes,storage:rules,functions --project <PROJECT_ID> --non-interactive
+firebase deploy --only firestore:rules,firestore:indexes,storage,functions --project <PROJECT_ID> --non-interactive
 
 - Rebuild iOS locally:
 flutter clean && flutter pub get

--- a/docs/ops/firebase-service-account.md
+++ b/docs/ops/firebase-service-account.md
@@ -46,7 +46,7 @@ As of 2025-08-15, CI deploys **Cloud Storage rules** alongside Firestore rules a
   - Tighten/relax rules by editing `storage.rules`; CI will deploy on merge.
   - For multi-bucket setups, add Storage targets in `firebase.json` and corresponding rules files; include those targets via `--only storage:<name>`.
 
-### 10) Storage deploy flag (important)
+### 10) Storage deploy flag (targets vs rules file)
 
 Use:
 
@@ -54,12 +54,12 @@ Use:
 firebase deploy --only firestore:rules,firestore:indexes,storage
 ```
 
-Do not use `storage:rules`. In the Firebase CLI, `storage:<name>` refers to a Storage target named `<name>` (configured via `firebase target:apply storage <name> <bucket>`).
+Do not use `storage:rules`. In the Firebase CLI, `storage:<name>` refers to a Storage target named `<name>` (created via `firebase target:apply storage <name> <bucket>`).
 
-When `firebase.json` has:
+Our repo uses a rules file wired in `firebase.json`:
 
 ```json
 "storage": { "rules": "storage.rules" }
 ```
 
-you deploy those rules with `--only storage`.
+so the correct filter is simply `--only storage`.

--- a/scripts/firebase_deploy.sh
+++ b/scripts/firebase_deploy.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 PROJECT="${1:-fouta-app}"
 echo "Deploying to $PROJECT ..."
-firebase deploy --only firestore:rules,firestore:indexes,storage:rules,functions --project "$PROJECT"
+firebase deploy --only firestore:rules,firestore:indexes,storage,functions --project "$PROJECT"


### PR DESCRIPTION
## Summary
- replace `--only storage:rules` with `--only storage` in deployment script
- clarify storage deploy flag semantics in docs
- record storage flag correction in history

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: package.json and lock file out of sync)*
- `npm test --if-present` *(fails: missing modules)*


------
https://chatgpt.com/codex/tasks/task_e_689fc82f0ef0832b88a745e2a5d682ab