### PR TITLE
Fix Firestore index: visibility field missing order

### DIFF
--- a/docs/history/2025-08-15-firestore-index-fix.md
+++ b/docs/history/2025-08-15-firestore-index-fix.md
@@ -1,0 +1,3 @@
+Fixed Firestore index deploy error: "Must contain exactly one of order, arrayConfig, vectorConfig" for `visibility` field.
+
+Added `"order": "ASCENDING"` to `visibility` field entries in `firestore.indexes.json`.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -50,7 +50,7 @@
       "collectionGroup": "posts",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "visibility", "op": "EQUAL" },
+        { "fieldPath": "visibility", "op": "EQUAL", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
     },


### PR DESCRIPTION
## Summary
- Added `"order": "ASCENDING"` to `visibility` field entries in `firestore.indexes.json`.
- Resolves deploy error: `"Must contain exactly one of order, arrayConfig, vectorConfig"`.

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: package-lock mismatch)*
- `npm test --if-present` *(fails: missing modules)*
- `firebase deploy --only firestore:indexes` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fcb903870832ba3721073b599e28b