### PR TITLE
CI: Resilient Functions install (prod-only) + docs

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -69,14 +69,29 @@ jobs:
             --token "${{ steps.token.outputs.token }}"
 
       - name: Deploy functions (if present)
+        if: ${{ hashFiles('functions/package.json') != '' }}
+        working-directory: functions
+        env:
+          FIREBASE_TOKEN: ${{ steps.token.outputs.token }}
+          FIREBASE_PROJECT_ID: ${{ env.FIREBASE_PROJECT_ID }}
         run: |
-          if [ -d "functions" ] && [ -f "functions/package.json" ]; then
-            npm --prefix functions ci
-            firebase deploy --non-interactive \
-              --project "$FIREBASE_PROJECT_ID" \
-              --only functions \
-              --token "${{ steps.token.outputs.token }}"
+          set -euo pipefail
+          echo "🔧 Preparing Cloud Functions (prod deps only)…"
+          if [ -f package-lock.json ]; then
+            echo "Trying npm ci --omit=dev (strict, fast)…"
+            if ! npm ci --omit=dev --no-audit --no-fund; then
+              echo "npm ci failed; falling back to npm install --omit=dev…"
+              npm install --omit=dev --no-audit --no-fund
+            fi
           else
-            echo "No functions dir; skipping"
+            echo "No package-lock.json found; using npm install --omit=dev…"
+            npm install --omit=dev --no-audit --no-fund
           fi
+
+          cd ..
+          echo "🚀 Deploying functions…"
+          firebase deploy --non-interactive \
+            --project "$FIREBASE_PROJECT_ID" \
+            --only functions \
+            --token "$FIREBASE_TOKEN"
 

--- a/docs/history/2025-08-16-functions-install-fallback.md
+++ b/docs/history/2025-08-16-functions-install-fallback.md
@@ -1,0 +1,6 @@
+Fixed CI failures caused by npm ci strictness in functions/.
+
+Added resilient install step: try npm ci --omit=dev; if it fails, fallback to npm install --omit=dev.
+
+Documented the policy and the stricter alternative (commit lockfile).
+

--- a/docs/ops/functions-deploy.md
+++ b/docs/ops/functions-deploy.md
@@ -1,0 +1,31 @@
+# Cloud Functions Deploy – Dependency Install Strategy
+
+**Why we changed this**
+- CI used `npm ci` inside `functions/`. This is strict and requires `functions/package-lock.json`
+  to be present and exactly in sync with `package.json`.
+- When the lockfile is missing or stale, `npm ci` fails with errors like:
+  `npm ci can only install packages when your package.json and package-lock.json are in sync…`
+
+**Policy**
+- In CI we attempt:
+  1. `npm ci --omit=dev --no-audit --no-fund`
+  2. If that fails, fall back to `npm install --omit=dev --no-audit --no-fund`.
+- We always omit dev dependencies for smaller/faster production builds.
+
+**Recommended (stricter) alternative**
+- Regenerate and commit a lockfile for functions:
+  ```bash
+  cd functions
+  rm -f package-lock.json
+  npm install        # produces fresh package-lock.json
+  git add package-lock.json
+  git commit -m "chore(functions): refresh lockfile"
+  ```
+  After that, CI will use the fast path (npm ci --omit=dev) reliably.
+
+**Notes on native/optional deps (e.g., sharp, ffmpeg)**
+
+Firebase Functions install on Google’s build environment; --omit=dev is safe for production.
+
+If a dependency must be available at runtime, keep it in dependencies (not devDependencies).
+


### PR DESCRIPTION
- Use npm ci --omit=dev for Functions, fallback to npm install --omit=dev when the lockfile is missing/out-of-sync.
- Prevents EUSAGE failures blocking deploy.
- Added docs on install policy and stricter lockfile approach for teams who want it.

------
https://chatgpt.com/codex/tasks/task_e_689fd1f41ad8832b8bb1fc727172a8a7