### PR TITLE
fix(ci): make Firestore index deploy idempotent and stable

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -30,8 +30,8 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install Firebase CLI
-        run: npm i -g firebase-tools
+      - name: Install Firebase CLI (pin)
+        run: npm i -g firebase-tools@14.10.1
 
       # Auth to Google using the service account JSON in FIREBASE_SERVICE_ACCOUNT
       - name: Authenticate to Google Cloud (workload identity)
@@ -61,13 +61,33 @@ jobs:
             --token "${{ steps.token.outputs.token }}" \
             "echo OK" || true
 
-      - name: Deploy rules & indexes
+      - name: Deploy Firestore/Storage rules
         run: |
           firebase deploy --non-interactive \
             --project "$FIREBASE_PROJECT_ID" \
-            --only firestore:rules,firestore:indexes,storage \
+            --only firestore:rules,storage \
             --force \
             --token "${{ steps.token.outputs.token }}"
+
+      - name: Deploy Firestore indexes (ignore 409 already-exists)
+        shell: bash
+        run: |
+          set -o pipefail
+          LOG=$(mktemp)
+          if firebase deploy --only firestore:indexes --non-interactive \
+              --project "$FIREBASE_PROJECT_ID" \
+              --force \
+              --token "${{ steps.token.outputs.token }}" 2>&1 | tee "$LOG"; then
+            echo "Indexes deployed."
+          else
+            if grep -qiE "409.*index already exists|ALREADY_EXISTS|already exists" "$LOG"; then
+              echo "Indexes already exist; treating as success."
+            else
+              echo "Deploy failed for a reason other than 409:"
+              cat "$LOG"
+              exit 1
+            fi
+          fi
 
       - name: Deploy functions (if present)
         if: ${{ hashFiles('functions/package.json') != '' }}


### PR DESCRIPTION
## Summary
- pin firebase-tools to 14.10.1 for stable index deploys
- split deploy: rules first, then indexes with graceful 409 handling

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: package-lock and package.json out of sync)*
- `npm test --if-present` *(fails: missing modules)*


------
https://chatgpt.com/codex/tasks/task_e_68a007860ecc832b96a705dd0b62dd7d