### PR TITLE
fix(functions): set Cloud Storage trigger region

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -170,7 +170,7 @@ const ffmpeg = require("@ffmpeg-installer/ffmpeg");
 const ffmpegLib = require("fluent-ffmpeg");
 ffmpegLib.setFfmpegPath(ffmpeg.path);
 
-exports.processMedia = onObjectFinalized(async (event) => {
+exports.processMedia = onObjectFinalized({ region: "us-east1" }, async (event) => {
   const object = event.data;
   const contentType = object.contentType || "";
   const filePath = object.name;


### PR DESCRIPTION
## Summary
- set `processMedia` Cloud Storage trigger region to `us-east1`

## Testing
- `npm ci` *(fails: package.json and lock file out of sync)*
- `npm test --if-present` *(fails: cannot find module 'firebase-admin')*
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a0903c2ed8832ba1720f2fd6f746e7