### PR TITLE
docs(ci): add Firebase deploy journey and link from workflows

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,5 +1,9 @@
 name: Firebase Deploy (rules, indexes, functions)
 # ------------------------------------------------------------------------------
+# Read first: docs/firebase-deploy-journey.md (full fixes & IAM roles)
+# Also: docs/ci-auth.md (ADC policy), docs/ai-collaboration.md (AI rules)
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # CI Auth Policy:
 # - Use Google ADC via google-github-actions/auth@v2 (Workload Identity or SA JSON)
 # - Do NOT use Firebase CLI tokens; do NOT pass --token

--- a/docs/firebase-deploy-journey.md
+++ b/docs/firebase-deploy-journey.md
@@ -1,0 +1,87 @@
+# Firebase CI/CD Deploy Journey (fouta-app)
+
+Canonical record of how we got GitHub Actions + Firebase deploys working for **fouta-app**. This prevents re-diagnosing known issues.
+
+**Project ID:** `fouta-app`  
+**Deployer SA:** `ci-firebase-deploy@fouta-app.iam.gserviceaccount.com`  
+**Runtime SAs:**  
+- App Engine default — `fouta-app@appspot.gserviceaccount.com`  
+- Compute Engine default — `<PROJECT_NUMBER>-compute@developer.gserviceaccount.com`
+
+---
+
+## Issues & Fixes
+
+### 1) Storage rules error
+**Error:** `Could not find rules for the following storage targets: rules`  
+**Fix:** Removed `:rules` target; `firebase.json` uses:
+```json
+"storage": { "rules": "storage.rules" }
+```
+
+### 2) Firestore index 409 (“already exists”)
+
+**Fix:** Split deploy:
+
+```
+firebase deploy --only firestore:rules,storage
+```
+
+Guarded step for firestore:indexes that ignores 409 only.
+
+### 3) Token auth deprecation
+
+**Fix:** Use ADC via google-github-actions/auth@v2 with create_credentials_file: true.
+Removed all --token / FIREBASE_TOKEN.
+
+### 4) IAM for Functions (Gen-2)
+
+Granted the deployer SA and service agents the required roles:
+
+ActAs on runtime SAs:
+
+roles/iam.serviceAccountUser on fouta-app@appspot.gserviceaccount.com
+
+roles/iam.serviceAccountUser on <PROJECT_NUMBER>-compute@developer.gserviceaccount.com
+
+Agents:
+
+Pub/Sub service agent — roles/pubsub.publisher
+
+Eventarc service agent — roles/eventarc.eventReceiver
+
+Cloud Build SA — roles/run.admin, roles/artifactregistry.writer, and ActAs on runtime SA
+
+Cloud Run service agent — ActAs on runtime SA
+
+Legacy gs agent — roles/pubsub.publisher
+
+### 5) Storage trigger region mismatch
+
+Error: function in us-central1 cannot listen to bucket in us-east1
+Fix: Set { region: 'us-east1' } on storage triggers (v2 options or functions.region('us-east1') in v1). Other triggers unchanged.
+
+### 6) Artifact Registry cleanup warning
+
+Fix: Add cleanup policies on gcf-artifacts in us-east1 and us-central1 (delete images older than 30 days).
+Repo script: tools/set_cleanup_policies.sh.
+
+## Final State
+
+CI uses ADC (no tokens).
+
+Functions deploy succeeds in us-central1 and us-east1.
+
+All required IAM bindings are in place.
+
+Artifact cleanup policies set; deploys no longer warn.
+
+## Also see
+
+docs/ci-auth.md — CI auth & IAM policy (ADC only)
+
+docs/ai-collaboration.md — AI rules (always read full repo)
+
+tools/set_cleanup_policies.sh — reapply Artifact Registry cleanup
+
+Last updated: 2025-08-16


### PR DESCRIPTION
## Summary
- document Firebase deploy fixes and IAM roles in `docs/firebase-deploy-journey.md`
- reference new deploy guide from Firebase deploy workflow header

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: lock file out of sync)*
- `npm test --if-present` *(fails: 2 tests failing)*

## Risks
- Future Firebase workflow files might omit the doc banner — **Mitigation:** document process in contributor guide.
- Deploy doc may become outdated — **Mitigation:** keep "Last updated" timestamp to encourage reviews.
- Missing Flutter/Dart tooling in CI leading to skipped checks — **Mitigation:** ensure CI images include Flutter SDK.
- `functions` tests currently failing — **Mitigation:** address failing tests or adjust test suite.
- Unsynced `package-lock.json` causing `npm ci` failure — **Mitigation:** update lock file before deployments.

## Migration
- No migrations required.

------
https://chatgpt.com/codex/tasks/task_e_68a0a225cf84832ba7142b4321db4fe1