### PR TITLE
Seller onboarding v1 (guided flow)

### DIFF
--- a/docs/product/seller-onboarding.md
+++ b/docs/product/seller-onboarding.md
@@ -1,0 +1,9 @@
+# Seller Onboarding Flow
+
+The onboarding wizard guides new sellers through three steps:
+
+1. **Profile basics** – display name, location, and contact info.
+2. **First product draft** – title, price, and up to three image URLs saved as a draft (`status: draft`).
+3. **Review & publish** – validates required fields then marks the draft as `published` and flags onboarding as complete.
+
+Draft data is stored in Firestore under `users/{uid}/meta/onboarding` and `products/{productId}`. Missing required fields during publish surface inline errors and block submission.

--- a/lib/features/marketplace/marketplace_service.dart
+++ b/lib/features/marketplace/marketplace_service.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 import '../../main.dart';
 import '../../utils/json_safety.dart';
@@ -13,6 +14,7 @@ class Product {
   final List<Uri> imageUris;      // canonical
   final String sellerId;
   final List<String> favoriteUserIds; // optional favorites
+  final String status;
 
   Product({
     required this.id,
@@ -23,6 +25,7 @@ class Product {
     this.description,
     List<Uri>? imageUris,
     List<String>? favoriteUserIds,
+    this.status = 'published',
   })  : imageUris = imageUris ?? const [],
         favoriteUserIds = favoriteUserIds ?? const [];
 
@@ -51,6 +54,7 @@ class Product {
       favoriteUserIds: ((map['favoriteUserIds'] as List?) ?? const [])
           .map((e) => e.toString())
           .toList(),
+      status: (map['status'] ?? 'published').toString(),
     );
   }
 
@@ -62,6 +66,7 @@ class Product {
         'imageUris': imageUris.map((u) => u.toString()).toList(),
         'sellerId': sellerId,
         'favoriteUserIds': favoriteUserIds,
+        'status': status,
       };
 }
 
@@ -92,6 +97,42 @@ class MarketplaceService {
     // ignore: unused_local_variable
     final priceCurrency = currency; // preserve compatibility
     return 'stub_prod_${DateTime.now().millisecondsSinceEpoch}';
+  }
+
+  /// Create a draft product under the current user.
+  Future<String> createDraftProduct({
+    required String title,
+    required double price,
+    required String currency,
+    List<Uri>? images,
+  }) async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) throw Exception('Not authenticated');
+    final doc = _collection.doc();
+    await doc.set({
+      'title': title,
+      'priceAmount': price,
+      'priceCurrency': currency,
+      'imageUris': (images ?? const []).map((u) => u.toString()).toList(),
+      'sellerId': uid,
+      'status': 'draft',
+    });
+    return doc.id;
+  }
+
+  /// Publish a draft product if required fields are present.
+  Future<void> publishProduct(String productId) async {
+    final doc = _collection.doc(productId);
+    final snap = await doc.get();
+    final data = snap.data();
+    if (data == null) throw Exception('not-found');
+    final hasTitle = (data['title'] ?? '').toString().isNotEmpty;
+    final hasPrice = data['priceAmount'] != null;
+    final hasImages = (data['imageUris'] as List?)?.isNotEmpty ?? false;
+    if (!hasTitle || !hasPrice || !hasImages) {
+      throw Exception('missing-fields');
+    }
+    await doc.update({'status': 'published'});
   }
 
   Future<void> toggleFavorite(String productId, String userId) async {

--- a/lib/features/marketplace/onboarding/seller_onboarding_flow.dart
+++ b/lib/features/marketplace/onboarding/seller_onboarding_flow.dart
@@ -1,0 +1,180 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+import '../marketplace_service.dart';
+
+/// Guided onboarding flow for first-time sellers.
+class SellerOnboardingFlow extends StatefulWidget {
+  const SellerOnboardingFlow({super.key});
+
+  @override
+  State<SellerOnboardingFlow> createState() => _SellerOnboardingFlowState();
+}
+
+class _SellerOnboardingFlowState extends State<SellerOnboardingFlow> {
+  final PageController _controller = PageController();
+  final _profileForm = GlobalKey<FormState>();
+  final _productForm = GlobalKey<FormState>();
+  final MarketplaceService _service = MarketplaceService();
+
+  // profile
+  String? _displayName;
+  String? _location;
+  String? _contact;
+
+  // product
+  String? _draftId;
+  String _title = '';
+  String _price = '';
+  final List<Uri> _images = [];
+
+  int _index = 0;
+
+  Future<void> _next() async {
+    if (_index == 0) {
+      if (!(_profileForm.currentState?.validate() ?? false)) return;
+      _profileForm.currentState?.save();
+      final uid = FirebaseAuth.instance.currentUser?.uid;
+      if (uid != null) {
+        await FirebaseFirestore.instance
+            .collection('users')
+            .doc(uid)
+            .collection('meta')
+            .doc('onboarding')
+            .set({
+          'displayName': _displayName,
+          'location': _location,
+          'contact': _contact,
+          'completed': false,
+        }, SetOptions(merge: true));
+      }
+      _controller.nextPage(duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
+    } else if (_index == 1) {
+      if (!(_productForm.currentState?.validate() ?? false)) return;
+      _productForm.currentState?.save();
+      final priceAmount = double.tryParse(_price) ?? 0;
+      _draftId = await _service.createDraftProduct(
+        title: _title,
+        price: priceAmount,
+        currency: 'USD',
+        images: _images,
+      );
+      _controller.nextPage(duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
+    } else if (_index == 2) {
+      if (_draftId == null) return;
+      try {
+        await _service.publishProduct(_draftId!);
+        final uid = FirebaseAuth.instance.currentUser?.uid;
+        if (uid != null) {
+          await FirebaseFirestore.instance
+              .collection('users')
+              .doc(uid)
+              .collection('meta')
+              .doc('onboarding')
+              .set({'completed': true}, SetOptions(merge: true));
+        }
+        if (mounted) Navigator.pop(context);
+      } catch (e) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Fill in required fields')));
+      }
+    }
+  }
+
+  Widget _buildProfile() {
+    return Form(
+      key: _profileForm,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextFormField(
+              decoration: const InputDecoration(labelText: 'Display name'),
+              validator: (v) => (v == null || v.isEmpty) ? 'Required' : null,
+              onSaved: (v) => _displayName = v,
+            ),
+            TextFormField(
+              decoration: const InputDecoration(labelText: 'Location'),
+              onSaved: (v) => _location = v,
+            ),
+            TextFormField(
+              decoration: const InputDecoration(labelText: 'Contact'),
+              onSaved: (v) => _contact = v,
+            ),
+            const Spacer(),
+            ElevatedButton(onPressed: _next, child: const Text('Next')),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildProduct() {
+    return Form(
+      key: _productForm,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextFormField(
+              decoration: const InputDecoration(labelText: 'Title'),
+              validator: (v) => (v == null || v.isEmpty) ? 'Required' : null,
+              onSaved: (v) => _title = v ?? '',
+            ),
+            TextFormField(
+              decoration: const InputDecoration(labelText: 'Price'),
+              keyboardType: TextInputType.number,
+              validator: (v) => (v == null || v.isEmpty) ? 'Required' : null,
+              onSaved: (v) => _price = v ?? '',
+            ),
+            TextFormField(
+              decoration: const InputDecoration(labelText: 'Image URL'),
+              onSaved: (v) {
+                if (v != null && v.isNotEmpty) {
+                  final uri = Uri.tryParse(v);
+                  if (uri != null) _images.add(uri);
+                }
+              },
+            ),
+            const Spacer(),
+            ElevatedButton(onPressed: _next, child: const Text('Next')),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildReview() {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text('Title: $_title'),
+          Text('Price: $_price'),
+          const Spacer(),
+          ElevatedButton(onPressed: _next, child: const Text('Publish')),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Start Selling')),
+      body: PageView(
+        controller: _controller,
+        physics: const NeverScrollableScrollPhysics(),
+        onPageChanged: (i) => setState(() => _index = i),
+        children: [
+          _buildProfile(),
+          _buildProduct(),
+          _buildReview(),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/features/marketplace/onboarding/seller_onboarding_nav.dart
+++ b/lib/features/marketplace/onboarding/seller_onboarding_nav.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+import 'seller_onboarding_flow.dart';
+
+Future<void> navigateToSellerOnboarding(BuildContext context) async {
+  await Navigator.of(context).push(
+    MaterialPageRoute(builder: (_) => const SellerOnboardingFlow()),
+  );
+}

--- a/lib/features/marketplace/product_card.dart
+++ b/lib/features/marketplace/product_card.dart
@@ -11,6 +11,7 @@ class ProductCard extends StatelessWidget {
     this.onFavorite,
     this.isFavorited = false,
     this.onSellerTap,
+    this.viewerId,
   });
 
   final Product product;
@@ -18,6 +19,7 @@ class ProductCard extends StatelessWidget {
   final VoidCallback? onFavorite;
   final bool isFavorited;
   final VoidCallback? onSellerTap;
+  final String? viewerId;
 
   @override
   Widget build(BuildContext context) {
@@ -44,6 +46,15 @@ class ProductCard extends StatelessWidget {
                             child: const Icon(Icons.image, size: 48),
                           ),
                   ),
+                  if (product.status == 'draft' && product.sellerId == viewerId)
+                    const Positioned(
+                      top: 4,
+                      left: 4,
+                      child: Chip(
+                        label: Text('Draft'),
+                        backgroundColor: Colors.orange,
+                      ),
+                    ),
                   Positioned(
                     top: 4,
                     right: 4,

--- a/lib/screens/marketplace_screen.dart
+++ b/lib/screens/marketplace_screen.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -6,12 +7,11 @@ import '../features/marketplace/marketplace_service.dart';
 import '../features/marketplace/product_detail_screen.dart';
 import 'package:fouta_app/features/marketplace/product_card.dart';
 import 'package:fouta_app/features/marketplace/create_product_nav.dart';
+import 'package:fouta_app/features/marketplace/onboarding/seller_onboarding_nav.dart';
 import 'marketplace_filters_sheet.dart';
 import 'seller_profile_screen.dart';
 import '../widgets/refresh_scaffold.dart';
 import '../widgets/safe_stream_builder.dart';
-import '../widgets/progressive_image.dart';
-import '../widgets/skeleton.dart';
 import '../widgets/fouta_button.dart';
 
 // TODO(IA): Align screen layout with docs/design/information-architecture.md after DS v1 adoption
@@ -81,6 +81,7 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
                       try {
                         return ProductCard(
                           product: product,
+                          viewerId: userId,
                           onTap: () {
                             Navigator.push(
                               context,
@@ -116,12 +117,39 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
           return Column(
             children: [
               if (user != null)
+                FutureBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+                  future: FirebaseFirestore.instance
+                      .collection('users')
+                      .doc(userId)
+                      .collection('meta')
+                      .doc('onboarding')
+                      .get(),
+                  builder: (context, snap) {
+                    final data = snap.data?.data();
+                    final incomplete = (data?['completed'] ?? true) == false;
+                    if (incomplete) {
+                      return ListTile(
+                        title: const Text('Finish setting up your shop'),
+                        trailing: TextButton(
+                          onPressed: () => navigateToSellerOnboarding(context),
+                          child: const Text('Resume'),
+                        ),
+                      );
+                    }
+                    return const SizedBox.shrink();
+                  },
+                ),
+              if (user != null)
                 Padding(
                   padding: const EdgeInsets.all(16),
                   child: FoutaButton(
                     label: hasListings ? 'Sell' : 'Start Selling',
                     onPressed: () async {
-                      await navigateToCreateProduct(context);
+                      if (hasListings) {
+                        await navigateToCreateProduct(context);
+                      } else {
+                        await navigateToSellerOnboarding(context);
+                      }
                     },
                     expanded: true,
                   ),
@@ -134,88 +162,4 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
     );
   }
 
-  Widget _buildProductCard(Product product, String userId) {
-    final image = product.urls.isNotEmpty ? product.urls.first : null;
-    return Card(
-      clipBehavior: Clip.hardEdge,
-      child: InkWell(
-        onTap: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (_) => ProductDetailScreen(product: product),
-            ),
-          );
-        },
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(
-              child: Stack(
-                children: [
-                  Positioned.fill(child: Skeleton.rect()),
-                  if (image != null)
-                    Positioned.fill(
-                      child: ProgressiveImage(
-                        imageUrl: image,
-                        thumbUrl: image,
-                        fit: BoxFit.cover,
-                      ),
-                    )
-                  else
-                    const Positioned.fill(
-                      child: Icon(Icons.image, size: 48),
-                    ),
-                  Positioned(
-                    top: 4,
-                    right: 4,
-                    child: IconButton(
-                      icon: Icon(
-                        product.favoriteUserIds.contains(userId)
-                            ? Icons.favorite
-                            : Icons.favorite_border,
-                        color: product.favoriteUserIds.contains(userId)
-                            ? Colors.red
-                            : Colors.white,
-                      ),
-                      onPressed: () => _service.toggleFavorite(product.id, userId),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.all(8),
-              child: Text(
-                product.title,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: Text('${product.currency}${product.price.toStringAsFixed(2)}'),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              child: GestureDetector(
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => SellerProfileScreen(sellerId: product.sellerId),
-                    ),
-                  );
-                },
-                child: Text(
-                  product.sellerId,
-                  style: Theme.of(context).textTheme.bodySmall,
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
 }

--- a/lib/screens/seller_profile_screen.dart
+++ b/lib/screens/seller_profile_screen.dart
@@ -110,7 +110,7 @@ class SellerProfileScreen extends StatelessWidget {
                   itemCount: products.length,
                   itemBuilder: (context, index) {
                     final product = products[index];
-                    return ProductCard(product: product);
+                    return ProductCard(product: product, viewerId: userId);
                   },
                 );
               },

--- a/test/a11y_focus_test.dart
+++ b/test/a11y_focus_test.dart
@@ -7,16 +7,17 @@ void main() {
   testWidgets('focused product card shows focus highlight', (tester) async {
     final product = Product(
       id: '1',
-      sellerId: 'seller',
-      urls: const [],
       title: 'Test',
-      category: 'c',
-      price: 1,
-      currency: 'USD',
+      priceAmount: 1,
+      priceCurrency: 'USD',
+      sellerId: 'seller',
+      imageUris: const [],
       favoriteUserIds: const [],
     );
 
-    await tester.pumpWidget(MaterialApp(home: ProductCard(product: product)));
+    await tester.pumpWidget(
+      MaterialApp(home: ProductCard(product: product, viewerId: 'viewer')),
+    );
 
     final inkFinder = find.descendant(
       of: find.byType(ProductCard),


### PR DESCRIPTION
## Summary
- Adds a 3-step onboarding wizard for sellers.
- Draft/publish flow wired to Firestore.
- Empty-state CTA and draft badge for owners.
- Docs for flow & states.

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: Missing lock file entries)*
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68a0aaa95250832bbfad10c1ef8fb45d