### PR TITLE
CI hardening: resilient functions install & skip when unchanged

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -92,26 +92,33 @@ jobs:
             fi
           fi
 
-      - name: Deploy functions (if present)
+      - name: Compute functions package hash
         if: ${{ hashFiles('functions/package.json') != '' }}
-        working-directory: functions
+        run: echo "FN_HASH=$(sha256sum functions/package.json | cut -d' ' -f1)" >> $GITHUB_ENV
+
+      - name: Cache functions node_modules
+        if: ${{ hashFiles('functions/package.json') != '' }}
+        uses: actions/cache@v4
+        with:
+          path: functions/node_modules
+          key: functions-${{ env.FN_HASH }}
+
+      - name: Deploy functions (if present)
+        if: ${{ env.FN_HASH != '' }}
         env:
           FIREBASE_PROJECT_ID: ${{ env.FIREBASE_PROJECT_ID }}
         run: |
           set -euo pipefail
-          echo "🔧 Preparing Cloud Functions (prod deps only)…"
-          if [ -f package-lock.json ]; then
-            echo "Trying npm ci --omit=dev (strict, fast)…"
-            if ! npm ci --omit=dev --no-audit --no-fund; then
-              echo "npm ci failed; falling back to npm install --omit=dev…"
-              npm install --omit=dev --no-audit --no-fund
-            fi
-          else
-            echo "No package-lock.json found; using npm install --omit=dev…"
-            npm install --omit=dev --no-audit --no-fund
+          if git diff --quiet HEAD~1 -- functions/; then
+            echo "No changes in functions; skipping deploy."
+            exit 0
           fi
 
+          echo "🔧 Preparing Cloud Functions (prod deps only)…"
+          cd functions
+          npm install --omit=dev --no-audit --no-fund
           cd ..
+
           echo "🚀 Deploying functions…"
           firebase deploy --non-interactive \
             --project "$FIREBASE_PROJECT_ID" \

--- a/docs/ops/firebase-ci-notes.md
+++ b/docs/ops/firebase-ci-notes.md
@@ -1,0 +1,6 @@
+# Firebase CI Notes
+
+- Use `npm install --no-audit --no-fund` in CI for Cloud Functions to tolerate `package-lock.json` drift that may occur locally.
+- Cache `functions/node_modules` with a key derived from `sha256sum functions/package.json` to avoid redundant installs.
+- Skip Cloud Functions deploy entirely when `git diff --quiet HEAD~1 -- functions/` finds no changes; rules, indexes, and storage deploy remain unaffected.
+


### PR DESCRIPTION
- Switch to npm install in CI to avoid lock drift breakage.
- Add hash-based cache + change gating for functions deploy.
- Doc updates for rationale.

------
https://chatgpt.com/codex/tasks/task_e_68a0ab17dd10832babae28a695518292