### PR TITLE
feat(marketplace): add seller onboarding flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- 2025-08-16 – feat(marketplace): add seller onboarding flow with Firestore-backed profiles.
 - 2025-08-12 America/New_York – fix(build): resolve trigger/widget API mismatches, nullability, and syntax issues; stabilize imports.
 
 

--- a/docs/dev-notes-marketplace.md
+++ b/docs/dev-notes-marketplace.md
@@ -3,4 +3,5 @@
 - AR camera has been stubbed and removed from settings until it is integrated into marketplace AR features.
 - Marketplace now shows a "Start Selling" banner to guide first-time sellers.
 - Once the product creation flow is ready, update `MarketplaceScreen` to link directly to the listing creation experience.
+- Seller onboarding screen collects basic profile info and appears when non-sellers tap "Start Selling".
 

--- a/docs/specs/TKT-207_v1.md
+++ b/docs/specs/TKT-207_v1.md
@@ -1,0 +1,44 @@
+# TKT-207 Seller Onboarding v1
+
+## Context
+Creators need a lightweight path to become sellers. Currently the "Start Selling" button goes straight to product creation without collecting seller details or persisting a seller profile.
+
+## Requirements & Acceptance Criteria
+- When a user taps "Start Selling" and does not yet have a seller profile, show a seller onboarding form.
+- Form collects `displayName` (required) and `bio` (optional).
+- Submitting the form creates a Firestore document under `sellers/{uid}` with `displayName`, optional `bio`, and `createdAt` timestamp.
+- After successful submission, navigate back to the Marketplace screen.
+- Existing sellers continue directly to the create product flow.
+
+## Data Contracts
+`/sellers/{uid}`
+```
+{
+  displayName: string,
+  bio?: string,
+  createdAt: Timestamp
+}
+```
+
+## Runtime Flags
+None for v1. Feature is gated by presence of seller profile.
+
+## Metrics
+- Count of completed seller onboarding flows.
+- Time from app install to first seller onboarding completion.
+
+## Risks
+1. **Abandoned forms** – mitigated by keeping form minimal.
+2. **Unauthorized writes** – Firestore rules must restrict to authenticated user ID (future work).
+3. **Data inconsistency** – handled via single document write.
+4. **Navigation loops** – after submission, ensure return to previous screen.
+5. **Accessibility issues** – rely on standard widgets and labels.
+
+## Test Plan
+- Unit test `SellerService` Firestore writes.
+- Widget tests verifying navigation to onboarding vs. product creation.
+- `flutter analyze`, `dart format`, `flutter test`.
+
+## Rollback Plan
+- Revert navigation to always open `CreateProductScreen`.
+- Remove `SellerOnboardingScreen` and `SellerService`.

--- a/lib/features/marketplace/create_product_nav.dart
+++ b/lib/features/marketplace/create_product_nav.dart
@@ -1,8 +1,25 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'create_product_screen.dart';
 
-Future<void> navigateToCreateProduct(BuildContext context) async {
+import 'create_product_screen.dart';
+import 'seller_onboarding_screen.dart';
+import 'seller_service.dart';
+
+/// Navigate to either seller onboarding or product creation depending on
+/// whether the current user is already a seller.
+Future<void> navigateToCreateProduct(
+  BuildContext context, {
+  SellerService? sellerService,
+  String? userId,
+}) async {
+  final uid = userId ?? FirebaseAuth.instance.currentUser?.uid;
+  if (uid == null) return;
+  final svc = sellerService ?? SellerService();
+  final isSeller = await svc.isSeller(uid);
+  final Widget screen = isSeller
+      ? const CreateProductScreen()
+      : const SellerOnboardingScreen();
   await Navigator.of(context).push(
-    MaterialPageRoute(builder: (_) => const CreateProductScreen()),
+    MaterialPageRoute(builder: (_) => screen),
   );
 }

--- a/lib/features/marketplace/seller_onboarding_screen.dart
+++ b/lib/features/marketplace/seller_onboarding_screen.dart
@@ -1,0 +1,79 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+import '../../widgets/fouta_button.dart';
+import 'seller_service.dart';
+
+class SellerOnboardingScreen extends StatefulWidget {
+  const SellerOnboardingScreen({super.key});
+
+  @override
+  State<SellerOnboardingScreen> createState() => _SellerOnboardingScreenState();
+}
+
+class _SellerOnboardingScreenState extends State<SellerOnboardingScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameCtrl = TextEditingController();
+  final _bioCtrl = TextEditingController();
+  bool _submitting = false;
+  final SellerService _service = SellerService();
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    _bioCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) return;
+    setState(() => _submitting = true);
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return;
+    await _service.createSellerProfile(
+      userId: uid,
+      displayName: _nameCtrl.text.trim(),
+      bio: _bioCtrl.text.trim(),
+    );
+    if (!mounted) return;
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Seller Setup')),
+      body: SafeArea(
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              TextFormField(
+                controller: _nameCtrl,
+                decoration: const InputDecoration(labelText: 'Display name'),
+                validator: (v) => (v == null || v.trim().isEmpty)
+                    ? 'Display name required'
+                    : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _bioCtrl,
+                decoration:
+                    const InputDecoration(labelText: 'Bio (optional)'),
+                maxLines: 3,
+              ),
+              const SizedBox(height: 24),
+              FoutaButton(
+                label: _submitting ? 'Submitting...' : 'Submit',
+                onPressed: _submitting ? null : _submit,
+                expanded: true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/marketplace/seller_service.dart
+++ b/lib/features/marketplace/seller_service.dart
@@ -1,0 +1,31 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Service for seller profile management.
+class SellerService {
+  SellerService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> get _collection =>
+      _firestore.collection('sellers');
+
+  /// Whether a seller profile exists for the given [userId].
+  Future<bool> isSeller(String userId) async {
+    final doc = await _collection.doc(userId).get();
+    return doc.exists;
+  }
+
+  /// Create or update a seller profile.
+  Future<void> createSellerProfile({
+    required String userId,
+    required String displayName,
+    String? bio,
+  }) async {
+    await _collection.doc(userId).set({
+      'displayName': displayName,
+      if (bio != null && bio.isNotEmpty) 'bio': bio,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+  }
+}

--- a/test/seller_onboarding_nav_test.dart
+++ b/test/seller_onboarding_nav_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fouta_app/features/marketplace/create_product_nav.dart';
+import 'package:fouta_app/features/marketplace/create_product_screen.dart';
+import 'package:fouta_app/features/marketplace/seller_onboarding_screen.dart';
+import 'package:fouta_app/features/marketplace/seller_service.dart';
+
+class _FakeSellerService extends SellerService {
+  _FakeSellerService(this._isSeller);
+  final bool _isSeller;
+  @override
+  Future<bool> isSeller(String userId) async => _isSeller;
+  @override
+  Future<void> createSellerProfile({
+    required String userId,
+    required String displayName,
+    String? bio,
+  }) async {}
+}
+
+void main() {
+  testWidgets('non-seller navigates to SellerOnboardingScreen', (tester) async {
+    final navKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(MaterialApp(navigatorKey: navKey, home: const Scaffold()));
+    await navigateToCreateProduct(navKey.currentContext!, sellerService: _FakeSellerService(false), userId: 'u1');
+    await tester.pumpAndSettle();
+    expect(find.byType(SellerOnboardingScreen), findsOneWidget);
+  });
+
+  testWidgets('seller navigates to CreateProductScreen', (tester) async {
+    final navKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(MaterialApp(navigatorKey: navKey, home: const Scaffold()));
+    await navigateToCreateProduct(navKey.currentContext!, sellerService: _FakeSellerService(true), userId: 'u1');
+    await tester.pumpAndSettle();
+    expect(find.byType(CreateProductScreen), findsOneWidget);
+  });
+}

--- a/test/seller_service_test.dart
+++ b/test/seller_service_test.dart
@@ -1,0 +1,20 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fouta_app/features/marketplace/seller_service.dart';
+
+void main() {
+  test('createSellerProfile stores document and isSeller returns true', () async {
+    final firestore = FakeFirebaseFirestore();
+    final service = SellerService(firestore: firestore);
+    await service.createSellerProfile(
+      userId: 'u1',
+      displayName: 'Alice',
+      bio: 'Hello',
+    );
+    final isSeller = await service.isSeller('u1');
+    expect(isSeller, isTrue);
+    final doc = await firestore.collection('sellers').doc('u1').get();
+    expect(doc.data()?['displayName'], 'Alice');
+  });
+}


### PR DESCRIPTION
## Summary
- add SellerService for Firestore-backed seller profiles
- route Start Selling to SellerOnboardingScreen before product creation
- document seller onboarding spec and marketplace dev notes

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed .` *(fails: command not found)*
- `flutter test --no-pub --coverage` *(fails: command not found)*
- `npm ci` *(fails: lock file out of sync)*
- `npm test --if-present` *(fails: cannot find module 'firebase-admin')*


------
https://chatgpt.com/codex/tasks/task_e_68a0ae90a480832bae91b4668e678816