### PR TITLE
Marketplace UX polish: filters, cards, images, states

### DIFF
--- a/docs/product/marketplace-ux.md
+++ b/docs/product/marketplace-ux.md
@@ -1,0 +1,15 @@
+# Marketplace UX
+
+## Filters and Sort
+- **Filters:** category, price range, location radius (km).
+- **Sort:** newest first, price ascending, price descending.
+- Preferences persist under `users/{uid}/meta/marketplaceFilters` and update listings live.
+
+## Product Card
+- 4:3 image area with shimmer placeholder and broken-image fallback.
+- Shows title, price, and seller.
+- Favorite button updates optimistically and retries once on failure.
+
+## States
+- Loading: grid skeletons matching card layout.
+- Empty: message indicating no products for current filters.

--- a/lib/features/marketplace/filters/filter_drawer.dart
+++ b/lib/features/marketplace/filters/filter_drawer.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+
+import '../../../widgets/fouta_card.dart';
+import 'marketplace_filters.dart';
+
+/// Drawer for adjusting marketplace filters. Updates persist per-user and
+/// emit changes live via [MarketplaceFiltersRepository].
+class MarketplaceFilterDrawer extends StatefulWidget {
+  const MarketplaceFilterDrawer({
+    super.key,
+    required this.repository,
+    required this.uid,
+  });
+
+  final MarketplaceFiltersRepository repository;
+  final String uid;
+
+  @override
+  State<MarketplaceFilterDrawer> createState() => _MarketplaceFilterDrawerState();
+}
+
+class _MarketplaceFilterDrawerState extends State<MarketplaceFilterDrawer> {
+  MarketplaceFilters _filters = const MarketplaceFilters();
+
+  @override
+  void initState() {
+    super.initState();
+    widget.repository.fetch(widget.uid).then((f) {
+      if (mounted) setState(() => _filters = f);
+    });
+  }
+
+  void _save(MarketplaceFilters f) {
+    setState(() => _filters = f);
+    widget.repository.save(widget.uid, f);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            FoutaCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('Price Range'),
+                  RangeSlider(
+                    values: RangeValues(
+                      _filters.minPrice ?? 0,
+                      _filters.maxPrice ?? 1000,
+                    ),
+                    min: 0,
+                    max: 1000,
+                    labels: RangeLabels(
+                      (_filters.minPrice ?? 0).toStringAsFixed(0),
+                      (_filters.maxPrice ?? 1000).toStringAsFixed(0),
+                    ),
+                    onChanged: (values) {
+                      _save(_filters.copyWith(
+                        minPrice: values.start,
+                        maxPrice: values.end == 1000 ? null : values.end,
+                      ));
+                    },
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 12),
+            FoutaCard(
+              child: Wrap(
+                spacing: 8,
+                children: [
+                  const Text('Category'),
+                  ..._categories.map((c) => FilterChip(
+                        label: Text(c),
+                        selected: _filters.category == c,
+                        onSelected: (_) => _save(
+                          _filters.copyWith(category: _filters.category == c ? null : c),
+                        ),
+                      )),
+                ],
+              ),
+            ),
+            const SizedBox(height: 12),
+            FoutaCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('Location Radius (km)'),
+                  Slider(
+                    value: _filters.radiusKm ?? 10,
+                    min: 1,
+                    max: 100,
+                    label: (_filters.radiusKm ?? 10).toStringAsFixed(0),
+                    onChanged: (v) => _save(
+                      _filters.copyWith(radiusKm: v),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 12),
+            FoutaCard(
+              child: Wrap(
+                spacing: 8,
+                children: [
+                  const Text('Sort'),
+                  ...MarketplaceSort.values.map(
+                    (s) => ChoiceChip(
+                      label: Text(_sortLabel(s)),
+                      selected: _filters.sort == s,
+                      onSelected: (_) => _save(_filters.copyWith(sort: s)),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+const _categories = ['Electronics', 'Home', 'Other'];
+
+String _sortLabel(MarketplaceSort s) {
+  switch (s) {
+    case MarketplaceSort.priceAsc:
+      return 'Price ↑';
+    case MarketplaceSort.priceDesc:
+      return 'Price ↓';
+    case MarketplaceSort.newest:
+    default:
+      return 'Newest';
+  }
+}

--- a/lib/features/marketplace/filters/marketplace_filters.dart
+++ b/lib/features/marketplace/filters/marketplace_filters.dart
@@ -1,0 +1,91 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../../main.dart';
+
+/// Sort options for marketplace listings.
+enum MarketplaceSort { newest, priceAsc, priceDesc }
+
+/// User-selected filters for marketplace queries.
+class MarketplaceFilters {
+  final String? category;
+  final double? minPrice;
+  final double? maxPrice;
+  final double? radiusKm;
+  final MarketplaceSort sort;
+
+  const MarketplaceFilters({
+    this.category,
+    this.minPrice,
+    this.maxPrice,
+    this.radiusKm,
+    this.sort = MarketplaceSort.newest,
+  });
+
+  factory MarketplaceFilters.fromMap(Map<String, dynamic>? map) {
+    map ??= const {};
+    return MarketplaceFilters(
+      category: map['category'] as String?,
+      minPrice: (map['minPrice'] as num?)?.toDouble(),
+      maxPrice: (map['maxPrice'] as num?)?.toDouble(),
+      radiusKm: (map['radiusKm'] as num?)?.toDouble(),
+      sort: MarketplaceSort.values.firstWhere(
+        (s) => s.name == (map['sort'] as String?),
+        orElse: () => MarketplaceSort.newest,
+      ),
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        if (category != null) 'category': category,
+        if (minPrice != null) 'minPrice': minPrice,
+        if (maxPrice != null) 'maxPrice': maxPrice,
+        if (radiusKm != null) 'radiusKm': radiusKm,
+        'sort': sort.name,
+      };
+
+  MarketplaceFilters copyWith({
+    String? category,
+    double? minPrice,
+    double? maxPrice,
+    double? radiusKm,
+    MarketplaceSort? sort,
+  }) {
+    return MarketplaceFilters(
+      category: category ?? this.category,
+      minPrice: minPrice ?? this.minPrice,
+      maxPrice: maxPrice ?? this.maxPrice,
+      radiusKm: radiusKm ?? this.radiusKm,
+      sort: sort ?? this.sort,
+    );
+  }
+}
+
+/// Handles persistence of [MarketplaceFilters] for each user.
+class MarketplaceFiltersRepository {
+  MarketplaceFiltersRepository({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  final FirebaseFirestore _firestore;
+
+  DocumentReference<Map<String, dynamic>> _doc(String uid) => _firestore
+      .collection('artifacts')
+      .doc(APP_ID)
+      .collection('public')
+      .doc('data')
+      .collection('users')
+      .doc(uid)
+      .collection('meta')
+      .doc('marketplaceFilters');
+
+  Future<void> save(String uid, MarketplaceFilters filters) async {
+    await _doc(uid).set(filters.toMap(), SetOptions(merge: true));
+  }
+
+  Future<MarketplaceFilters> fetch(String uid) async {
+    final snap = await _doc(uid).get();
+    return MarketplaceFilters.fromMap(snap.data());
+  }
+
+  Stream<MarketplaceFilters> watch(String uid) {
+    return _doc(uid).snapshots().map((s) => MarketplaceFilters.fromMap(s.data()));
+  }
+}

--- a/lib/features/marketplace/marketplace_service.dart
+++ b/lib/features/marketplace/marketplace_service.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 import '../../main.dart';
 import '../../utils/json_safety.dart';
+import 'filters/marketplace_filters.dart';
 
 /// Marketplace product domain model.
 class Product {
@@ -13,6 +14,7 @@ class Product {
   final List<Uri> imageUris;      // canonical
   final String sellerId;
   final List<String> favoriteUserIds; // optional favorites
+  final String? category;
 
   Product({
     required this.id,
@@ -23,6 +25,7 @@ class Product {
     this.description,
     List<Uri>? imageUris,
     List<String>? favoriteUserIds,
+    this.category,
   })  : imageUris = imageUris ?? const [],
         favoriteUserIds = favoriteUserIds ?? const [];
 
@@ -51,6 +54,7 @@ class Product {
       favoriteUserIds: ((map['favoriteUserIds'] as List?) ?? const [])
           .map((e) => e.toString())
           .toList(),
+      category: (map['category'] as String?)?.trim(),
     );
   }
 
@@ -62,6 +66,7 @@ class Product {
         'imageUris': imageUris.map((u) => u.toString()).toList(),
         'sellerId': sellerId,
         'favoriteUserIds': favoriteUserIds,
+        if (category != null) 'category': category,
       };
 }
 
@@ -125,6 +130,7 @@ extension MarketplaceQueries on MarketplaceService {
   /// TEMP: return small list for screens that expect listings.
   Future<List<Product>> listProducts({int limit = 10}) async {
     await Future.delayed(const Duration(milliseconds: 100));
+    const cats = ['Electronics', 'Home', 'Other'];
     return List<Product>.generate(limit, (i) {
       return Product(
         id: 'demo_$i',
@@ -135,22 +141,82 @@ extension MarketplaceQueries on MarketplaceService {
         imageUris: const [],
         sellerId: 'demo-user',
         favoriteUserIds: i.isEven ? const ['demo-user'] : const [],
+        category: cats[i % cats.length],
       );
     });
   }
 
-  /// Stream products for list UIs (stub).
+  /// Stream products for list UIs (stub) that applies [filters] and [sort].
   Stream<List<Product>> streamProducts({
-    String? category,
-    double? minPrice,
-    double? maxPrice,
-    String? query,
+    MarketplaceFilters? filters,
     int limit = 20,
   }) async* {
-    yield await listProducts(limit: limit);
+    filters ??= const MarketplaceFilters();
+    var items = await listProducts(limit: limit);
+    items = _applyFilters(items, filters);
+    items = _applySort(items, filters.sort);
+    yield items;
     await for (final _ in Stream<void>.periodic(const Duration(seconds: 10))) {
-      yield await listProducts(limit: limit);
+      var refreshed = await listProducts(limit: limit);
+      refreshed = _applyFilters(refreshed, filters!);
+      refreshed = _applySort(refreshed, filters.sort);
+      yield refreshed;
     }
+  }
+
+  List<Product> _applyFilters(List<Product> items, MarketplaceFilters filters) {
+    return items.where((p) {
+      final matchesCategory = filters.category == null || p.category == filters.category;
+      final matchesMin = filters.minPrice == null || p.priceAmount >= filters.minPrice!;
+      final matchesMax = filters.maxPrice == null || p.priceAmount <= filters.maxPrice!;
+      return matchesCategory && matchesMin && matchesMax;
+    }).toList();
+  }
+
+  List<Product> _applySort(List<Product> items, MarketplaceSort sort) {
+    switch (sort) {
+      case MarketplaceSort.priceAsc:
+        items.sort((a, b) => a.priceAmount.compareTo(b.priceAmount));
+        break;
+      case MarketplaceSort.priceDesc:
+        items.sort((a, b) => b.priceAmount.compareTo(a.priceAmount));
+        break;
+      case MarketplaceSort.newest:
+      default:
+        items.sort((a, b) => b.id.compareTo(a.id));
+    }
+    return items;
+  }
+
+  /// Build a Firestore query for products applying [filters] and [limit].
+  /// Keeping orderBy on the same field as range filters avoids extra indexes.
+  Query<Map<String, dynamic>> buildQuery({
+    MarketplaceFilters? filters,
+    int limit = 20,
+  }) {
+    filters ??= const MarketplaceFilters();
+    Query<Map<String, dynamic>> q = _collection.limit(limit);
+    if (filters.category != null) {
+      q = q.where('category', isEqualTo: filters.category);
+    }
+    if (filters.minPrice != null) {
+      q = q.where('priceAmount', isGreaterThanOrEqualTo: filters.minPrice);
+    }
+    if (filters.maxPrice != null) {
+      q = q.where('priceAmount', isLessThanOrEqualTo: filters.maxPrice);
+    }
+    switch (filters.sort) {
+      case MarketplaceSort.priceAsc:
+        q = q.orderBy('priceAmount');
+        break;
+      case MarketplaceSort.priceDesc:
+        q = q.orderBy('priceAmount', descending: true);
+        break;
+      case MarketplaceSort.newest:
+      default:
+        q = q.orderBy('createdAt', descending: true);
+    }
+    return q;
   }
 }
 

--- a/lib/features/marketplace/product_card.dart
+++ b/lib/features/marketplace/product_card.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 
 import 'marketplace_service.dart';
 import 'package:fouta_app/theme/tokens.dart';
+import '../../widgets/skeleton.dart';
 
-class ProductCard extends StatelessWidget {
+class ProductCard extends StatefulWidget {
   const ProductCard({
     super.key,
     required this.product,
@@ -15,44 +16,77 @@ class ProductCard extends StatelessWidget {
 
   final Product product;
   final VoidCallback? onTap;
-  final VoidCallback? onFavorite;
+  final Future<void> Function()? onFavorite;
   final bool isFavorited;
   final VoidCallback? onSellerTap;
 
   @override
+  State<ProductCard> createState() => _ProductCardState();
+}
+
+class _ProductCardState extends State<ProductCard> {
+  late bool _favorited = widget.isFavorited;
+
+  Future<void> _handleFavorite() async {
+    setState(() => _favorited = !_favorited);
+    if (widget.onFavorite == null) return;
+    try {
+      await widget.onFavorite!.call();
+    } catch (_) {
+      // revert and retry once
+      setState(() => _favorited = !_favorited);
+      try {
+        await widget.onFavorite!.call();
+        setState(() => _favorited = !_favorited);
+      } catch (e) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to update favorite')),
+        );
+      }
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final image = product.urls.isNotEmpty ? product.urls.first : null;
+    final image = widget.product.urls.isNotEmpty ? widget.product.urls.first : null;
     return Card(
       clipBehavior: Clip.hardEdge,
       child: InkWell(
-        onTap: onTap,
+        onTap: widget.onTap,
         focusColor: AppColors.primary.withOpacity(0.3),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Expanded(
+            AspectRatio(
+              aspectRatio: 4 / 3,
               child: Stack(
                 children: [
-                  Positioned.fill(
-                    child: image != null
-                        ? Semantics(
-                            label: 'Product image: ${product.title}',
-                            child: Image.network(image, width: double.infinity, fit: BoxFit.cover),
-                          )
-                        : Container(
-                            color: Colors.grey.shade300,
-                            child: const Icon(Icons.image, size: 48),
-                          ),
-                  ),
+                  Positioned.fill(child: Skeleton.rect()),
+                  if (image != null)
+                    Positioned.fill(
+                      child: Image.network(
+                        image,
+                        fit: BoxFit.cover,
+                        loadingBuilder: (context, child, progress) {
+                          if (progress == null) {
+                            return child;
+                          }
+                          return Skeleton.rect();
+                        },
+                        errorBuilder: (_, __, ___) => const Icon(Icons.broken_image),
+                      ),
+                    )
+                  else
+                    const Center(child: Icon(Icons.image, size: 48)),
                   Positioned(
                     top: 4,
                     right: 4,
                     child: IconButton(
                       icon: Icon(
-                        isFavorited ? Icons.favorite : Icons.favorite_border,
-                        color: isFavorited ? Colors.red : Colors.white,
+                        _favorited ? Icons.favorite : Icons.favorite_border,
+                        color: _favorited ? Colors.red : Colors.white,
                       ),
-                      onPressed: onFavorite,
+                      onPressed: _handleFavorite,
                     ),
                   ),
                 ],
@@ -61,7 +95,7 @@ class ProductCard extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.all(8),
               child: Text(
-                product.title,
+                widget.product.title,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 softWrap: false,
@@ -69,15 +103,15 @@ class ProductCard extends StatelessWidget {
             ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: Text('${product.currency}${product.price.toStringAsFixed(2)}'),
+              child: Text('${widget.product.currency}${widget.product.price.toStringAsFixed(2)}'),
             ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
               child: InkWell(
-                onTap: onSellerTap,
+                onTap: widget.onSellerTap,
                 focusColor: AppColors.primary.withOpacity(0.3),
                 child: Text(
-                  product.sellerId,
+                  widget.product.sellerId,
                   style: Theme.of(context).textTheme.bodySmall,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,

--- a/lib/features/marketplace/skeletons.dart
+++ b/lib/features/marketplace/skeletons.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import '../../widgets/skeleton.dart';
+
+/// Skeleton card matching [ProductCard] layout.
+class MarketplaceCardSkeleton extends StatelessWidget {
+  const MarketplaceCardSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      clipBehavior: Clip.hardEdge,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const AspectRatio(aspectRatio: 4 / 3, child: Skeleton.rect()),
+          const Padding(
+            padding: EdgeInsets.all(8),
+            child: Skeleton.line(width: 80),
+          ),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 8),
+            child: Skeleton.line(width: 40),
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}
+
+/// Grid of [MarketplaceCardSkeleton] used while loading.
+class MarketplaceListSkeleton extends StatelessWidget {
+  const MarketplaceListSkeleton({super.key, this.count = 6});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final crossAxisCount = constraints.maxWidth > 600 ? 3 : 2;
+        return GridView.builder(
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: crossAxisCount,
+            childAspectRatio: 3 / 4,
+          ),
+          itemCount: count,
+          itemBuilder: (_, __) => const MarketplaceCardSkeleton(),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/marketplace_screen.dart
+++ b/lib/screens/marketplace_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -6,12 +8,12 @@ import '../features/marketplace/marketplace_service.dart';
 import '../features/marketplace/product_detail_screen.dart';
 import 'package:fouta_app/features/marketplace/product_card.dart';
 import 'package:fouta_app/features/marketplace/create_product_nav.dart';
-import 'marketplace_filters_sheet.dart';
+import '../features/marketplace/filters/marketplace_filters.dart';
+import '../features/marketplace/filters/filter_drawer.dart';
+import '../features/marketplace/skeletons.dart';
 import 'seller_profile_screen.dart';
 import '../widgets/refresh_scaffold.dart';
 import '../widgets/safe_stream_builder.dart';
-import '../widgets/progressive_image.dart';
-import '../widgets/skeleton.dart';
 import '../widgets/fouta_button.dart';
 
 // TODO(IA): Align screen layout with docs/design/information-architecture.md after DS v1 adoption
@@ -24,18 +26,32 @@ class MarketplaceScreen extends StatefulWidget {
 
 class _MarketplaceScreenState extends State<MarketplaceScreen> {
   final MarketplaceService _service = MarketplaceService();
-  MarketplaceFilters _filters = MarketplaceFilters();
+  final MarketplaceFiltersRepository _repo = MarketplaceFiltersRepository();
+  MarketplaceFilters _filters = const MarketplaceFilters();
+  StreamSubscription<MarketplaceFilters>? _sub;
 
-  void _openFilters() {
+  void _openFilters(String uid) {
     showModalBottomSheet(
       context: context,
-      builder: (_) => MarketplaceFiltersSheet(
-        initial: _filters,
-        onApply: (f) {
-          setState(() => _filters = f);
-        },
-      ),
+      builder: (_) => MarketplaceFilterDrawer(repository: _repo, uid: uid),
     );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid != null) {
+      _sub = _repo.watch(uid).listen((f) {
+        setState(() => _filters = f);
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
   }
 
   @override
@@ -46,23 +62,23 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
       appBar: AppBar(
         title: const Text('Marketplace'),
         actions: [
-          IconButton(onPressed: _openFilters, icon: const Icon(Icons.filter_list)),
+          IconButton(
+            onPressed: () => _openFilters(userId),
+            icon: const Icon(Icons.filter_list),
+          ),
         ],
       ),
       body: SafeStreamBuilder<List<Product>>(
-        stream: _service.streamProducts(
-          limit: 20,
-          category: _filters.category,
-          minPrice: _filters.minPrice,
-          maxPrice: _filters.maxPrice,
-          query: _filters.query,
-        ),
+        stream: _service.streamProducts(filters: _filters, limit: 20),
         builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const MarketplaceListSkeleton();
+          }
           final products = snapshot.data ?? [];
           final hasListings = products.any((p) => p.sellerId == userId);
           Widget content;
           if (products.isEmpty) {
-            content = const Center(child: Text('No products'));
+            content = const Center(child: Text('No products match your filters'));
           } else {
             content = LayoutBuilder(
               builder: (context, constraints) {
@@ -78,34 +94,27 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
                     itemCount: products.length,
                     itemBuilder: (context, index) {
                       final product = products[index];
-                      try {
-                        return ProductCard(
-                          product: product,
-                          onTap: () {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (_) => ProductDetailScreen(product: product),
-                              ),
-                            );
-                          },
-                          onFavorite: () => _service.toggleFavorite(product.id, userId),
-                          isFavorited: product.favoriteUserIds.contains(userId),
-                          onSellerTap: () {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (_) => SellerProfileScreen(sellerId: product.sellerId),
-                              ),
-                            );
-                          },
-                        );
-                      } catch (e) {
-                        if (kDebugMode) {
-                          print('Error rendering product ${product.id}: $e');
-                        }
-                        return const SizedBox.shrink();
-                      }
+                      return ProductCard(
+                        product: product,
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => ProductDetailScreen(product: product),
+                            ),
+                          );
+                        },
+                        onFavorite: () => _service.toggleFavorite(product.id, userId),
+                        isFavorited: product.favoriteUserIds.contains(userId),
+                        onSellerTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => SellerProfileScreen(sellerId: product.sellerId),
+                            ),
+                          );
+                        },
+                      );
                     },
                   ),
                 );
@@ -134,88 +143,4 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
     );
   }
 
-  Widget _buildProductCard(Product product, String userId) {
-    final image = product.urls.isNotEmpty ? product.urls.first : null;
-    return Card(
-      clipBehavior: Clip.hardEdge,
-      child: InkWell(
-        onTap: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (_) => ProductDetailScreen(product: product),
-            ),
-          );
-        },
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(
-              child: Stack(
-                children: [
-                  Positioned.fill(child: Skeleton.rect()),
-                  if (image != null)
-                    Positioned.fill(
-                      child: ProgressiveImage(
-                        imageUrl: image,
-                        thumbUrl: image,
-                        fit: BoxFit.cover,
-                      ),
-                    )
-                  else
-                    const Positioned.fill(
-                      child: Icon(Icons.image, size: 48),
-                    ),
-                  Positioned(
-                    top: 4,
-                    right: 4,
-                    child: IconButton(
-                      icon: Icon(
-                        product.favoriteUserIds.contains(userId)
-                            ? Icons.favorite
-                            : Icons.favorite_border,
-                        color: product.favoriteUserIds.contains(userId)
-                            ? Colors.red
-                            : Colors.white,
-                      ),
-                      onPressed: () => _service.toggleFavorite(product.id, userId),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.all(8),
-              child: Text(
-                product.title,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: Text('${product.currency}${product.price.toStringAsFixed(2)}'),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              child: GestureDetector(
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => SellerProfileScreen(sellerId: product.sellerId),
-                    ),
-                  );
-                },
-                child: Text(
-                  product.sellerId,
-                  style: Theme.of(context).textTheme.bodySmall,
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
 }

--- a/test/a11y_focus_test.dart
+++ b/test/a11y_focus_test.dart
@@ -8,11 +8,11 @@ void main() {
     final product = Product(
       id: '1',
       sellerId: 'seller',
-      urls: const [],
+      imageUris: const [],
       title: 'Test',
       category: 'c',
-      price: 1,
-      currency: 'USD',
+      priceAmount: 1,
+      priceCurrency: 'USD',
       favoriteUserIds: const [],
     );
 


### PR DESCRIPTION
- Filter drawer and sort rules with persisted preferences.
- Consistent card visuals + optimistic favorites.
- Skeletons and empty-state improvements.

------
https://chatgpt.com/codex/tasks/task_e_68a0ab019a58832ba441365e943fd8d2